### PR TITLE
팀 가드 구현

### DIFF
--- a/apps/backend/src/teams/team-member.guard.ts
+++ b/apps/backend/src/teams/team-member.guard.ts
@@ -1,0 +1,36 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, NotFoundException } from "@nestjs/common";
+import { TeamRepository } from "./repositories/team.repository";
+import { AuthenticatedRequest } from "src/oidc/interfaces/oidc.interface";
+
+@Injectable()
+export class TeamMemberGuard implements CanActivate {
+  constructor(private readonly teamRepository: TeamRepository) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const user = request.user;
+
+    // 라우트 파라미터 :uuid 우선, 없으면 쿼리 파라미터 ?teamId fallback
+    const teamUuid = (request.params?.uuid as string) || (request.query?.teamId as string);
+
+    if (!teamUuid) {
+      throw new ForbiddenException("팀 식별자가 필요합니다");
+    }
+
+    const team = await this.teamRepository.findByUuid(teamUuid);
+    if (!team) {
+      throw new NotFoundException("팀을 찾을 수 없습니다");
+    }
+
+    const member = await this.teamRepository.findMember(team.id, user.userId);
+    if (!member) {
+      throw new ForbiddenException("해당 팀의 멤버만 접근할 수 있습니다");
+    }
+
+    // 후속 컨트롤러에서 재조회 방지
+    (request as any).team = team;
+    (request as any).teamMember = member;
+
+    return true;
+  }
+}

--- a/apps/backend/src/teams/teams.module.ts
+++ b/apps/backend/src/teams/teams.module.ts
@@ -5,11 +5,12 @@ import { TeamRepository } from "./repositories/team.repository";
 import { DatabaseModule } from "../database/database.module";
 import { OidcModule } from "../oidc/oidc.module";
 import { UserModule } from "src/user/user.module";
+import { TeamMemberGuard } from "./team-member.guard";
 
 @Module({
   imports: [DatabaseModule, OidcModule, UserModule],
   controllers: [TeamsController],
-  providers: [TeamsService, TeamRepository],
-  exports: [TeamsService],
+  providers: [TeamsService, TeamRepository, TeamMemberGuard],
+  exports: [TeamsService, TeamMemberGuard],
 })
 export class TeamsModule {}


### PR DESCRIPTION
DB 기반으로 요청 사용자가 해당 팀의 멤버인지 검증하는 NestJS 가드를 구현했습니다. 
OidcGuard 이후에 실행되는 것을 전제했습니다.

마지막 `후속 컨트롤러에서 재조회 방지` 부분은 가드에서 DB로 팀과 멤버를 조회했으니까, 그 결과를 request 객체에 붙여두는 것입니다. 이렇게 하면 컨트롤러나 서비스에서 같은 데이터를 또 db 조회하지 않아도 될 것 같습니다. 
예를 들어 가드 없이는
- 가드: findByUuid(uuid) → 팀 조회, findMember() → 멤버 조회
- 서비스: findByUuid(uuid) → 또 팀 조회, findMember() → 또 멤버 조회
가드에서 request.team에 저장해두면 컨트롤러에서 바로 꺼내 쓸 수 있어서 중복 DB 쿼리를 줄입니다.

다만 현재 구조에서는 컨트롤러가 request 객체에 직접 접근하지 않고 서비스에 uuid를 넘기는 패턴이니, 지금 단계에서는 이 부분을 빼고 단순하게 가는 것도 괜찮습니다. 

전체적으로 수정해도 괜찮은 코드이고 당장 필요하다고 생각해 먼저 구현했습니다.