### PR TITLE
Feat/188 팀별 웹훅 URL 관리를 위한 TeamWebhook 테이블 추가

### DIFF
--- a/apps/backend/prisma/migrations/20260129025434_add_team_webhook/migration.sql
+++ b/apps/backend/prisma/migrations/20260129025434_add_team_webhook/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "team_webhooks" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "uuid" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "team_id" INTEGER NOT NULL,
+    CONSTRAINT "team_webhooks_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "team_webhooks_uuid_key" ON "team_webhooks"("uuid");
+
+-- CreateIndex
+CREATE INDEX "team_webhooks_team_id_idx" ON "team_webhooks"("team_id");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -33,9 +33,10 @@ model Team {
   createdAt DateTime @default(now()) @map("created_at")
 
   // 관계 설정
-  members Member[] // 팀에 소속된 멤버 목록
-  folders Folder[] // 팀에 속한 폴더들
-  links   Link[]   // 팀에 속한 전체 링크들
+  members  Member[]      // 팀에 소속된 멤버 목록
+  folders  Folder[]      // 팀에 속한 폴더들
+  links    Link[]        // 팀에 속한 전체 링크들
+  webhooks TeamWebhook[] // 팀에 등록된 웹훅들
 
   @@map("teams")
 }
@@ -117,4 +118,23 @@ model Link {
   @@index([folderId])
   @@index([createdBy])
   @@map("links")
+}
+
+// --------------------------------------------------------
+// 6. TeamWebhook (팀별 웹훅 URL 관리)
+// --------------------------------------------------------
+model TeamWebhook {
+  id       Int     @id @default(autoincrement())
+  uuid     String  @unique @default(uuid()) // 외부 노출용 식별자
+  url      String
+  isActive Boolean @default(true) @map("is_active")
+
+  // 외래 키
+  teamId Int @map("team_id")
+
+  // 관계 설정
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@index([teamId])
+  @@map("team_webhooks")
 }


### PR DESCRIPTION
## 관련 이슈
- close #188 

## 작업 내용

- 새로운 테이블 "team_webhooks" 생성
- 팀 모델에 webhooks 필드 추가
- TeamWebhook 모델 정의 및 관계 설정

## 목적

- 팀별 웹훅 URL을 저장하여 링크 생성 시 해당 웹훅에 링크 생성 정보 전달용도
- 예를들어 A팀에 3개의 웹훅이 들어간다면, 모두 트리거하기 위함
- 후속 PR에서 웹훅 조회/추가/제거/토글 API 작성 예정