### PR TITLE
Feat/211 선택되지 않은 팀의 폴더 생성/삭제 시 안내 alert 추가

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -194,7 +194,33 @@ const Sidebar = ({
 
   const handleCreateFolderClick = (e: React.MouseEvent, teamUuid: string) => {
     e.stopPropagation();
+
+    // 선택된 팀이 아닌 경우 alert 표시
+    if (teamUuid !== selectedTeamUuid) {
+      const targetTeam = teams.find((t) => t.teamUuid === teamUuid);
+      const teamName = targetTeam?.teamName || "해당";
+      alert(`${teamName} 팀 페이지에서 폴더를 생성할 수 있습니다.`);
+      return;
+    }
+
     onCreateFolder?.(teamUuid);
+  };
+
+  const handleDeleteFolderClick = (
+    e: React.MouseEvent,
+    team: Team,
+    folderUuid: string,
+    folderName: string,
+  ) => {
+    e.stopPropagation();
+
+    // 선택된 팀이 아닌 경우 alert 표시
+    if (team.teamUuid !== selectedTeamUuid) {
+      alert(`${team.teamName} 팀 페이지에서 폴더를 삭제할 수 있습니다.`);
+      return;
+    }
+
+    onDeleteFolder?.(team.teamUuid, folderUuid, folderName);
   };
 
   return (
@@ -357,14 +383,14 @@ const Sidebar = ({
                               {/* 호버 시 삭제 버튼 (기본 폴더 제외) */}
                               {!isDefaultFolder && (
                                 <button
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onDeleteFolder?.(
-                                      team.teamUuid,
+                                  onClick={(e) =>
+                                    handleDeleteFolderClick(
+                                      e,
+                                      team,
                                       folder.folderUuid,
                                       folder.folderName,
-                                    );
-                                  }}
+                                    )
+                                  }
                                   className={`p-1 hover:bg-gray-200 rounded cursor-pointer transition-opacity duration-150 ${
                                     isFolderHovered
                                       ? "opacity-100"


### PR DESCRIPTION
선택되지 않은 팀의 폴더를 생성하거나 삭제하려고 할 때 안내 alert를 표시하도록 했습니다.

closes #211 

### 작업 내용
- 사이드바에서 현재 선택된 팀이 아닌 다른 팀의 폴더 생성/삭제 버튼 클릭 시 해당 팀 페이지로 이동하라는 안내 alert 표시
- 캐시 갱신 메커니즘의 한계로 인해 다른 팀의 폴더 조작이 UI에 즉시 반영되지 않는 문제를 UX로 해결


https://github.com/user-attachments/assets/d6d5f367-e20d-459a-86d8-347c18c8e779

