### PR TITLE
Refactor/251 Layout 컴포넌트 추출 및 페이지 적용

### DIFF
--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -4,9 +4,10 @@ import { useNavigate } from "react-router-dom";
 
 interface HeaderProps {
   showMyPageLink?: boolean;
+  extraButtons?: React.ReactNode;
 }
 
-const Header = ({ showMyPageLink = true }: HeaderProps) => {
+const Header = ({ showMyPageLink = true, extraButtons }: HeaderProps) => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
 
@@ -30,6 +31,7 @@ const Header = ({ showMyPageLink = true }: HeaderProps) => {
             {user?.nickname || user?.email?.split("@")[0]}
           </span>
         )}
+        {extraButtons}
         <button
           onClick={handleLogout}
           className="flex items-center gap-2 px-3 py-1.5 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"

--- a/apps/frontend/src/components/layout/Layout.tsx
+++ b/apps/frontend/src/components/layout/Layout.tsx
@@ -1,0 +1,49 @@
+import type { Folder } from "../../types";
+import Sidebar from "./Sidebar";
+import Header from "./Header";
+
+interface SidebarProps {
+  onCreateTeam?: () => void;
+  onCreateFolder?: (teamUuid: string) => void;
+  onDeleteFolder?: (
+    teamUuid: string,
+    folderUuid: string,
+    folderName: string,
+  ) => void;
+  selectedFolderUuid?: string | null;
+  onFolderSelect?: (folder: Folder) => void;
+  folderRefreshKey?: number;
+}
+
+interface HeaderProps {
+  showMyPageLink?: boolean;
+  extraButtons?: React.ReactNode;
+}
+
+interface LayoutProps {
+  children: React.ReactNode;
+  sidebarProps?: SidebarProps;
+  headerProps?: HeaderProps;
+}
+
+const Layout = ({ children, sidebarProps = {}, headerProps = {} }: LayoutProps) => {
+  return (
+    <div className="flex h-screen bg-gray-50">
+      {/* 사이드바 */}
+      <Sidebar {...sidebarProps} />
+
+      {/* 메인 영역 */}
+      <div className="flex-1 flex flex-col">
+        {/* 헤더 */}
+        <Header {...headerProps} />
+
+        {/* 컨텐츠 */}
+        <main className="flex-1 p-8 overflow-auto">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default Layout;

--- a/apps/frontend/src/pages/MyPage.tsx
+++ b/apps/frontend/src/pages/MyPage.tsx
@@ -2,8 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { useTeams } from "../contexts/TeamContext";
 import { Crown, Users, UserX } from "lucide-react";
-import Sidebar from "../components/layout/Sidebar";
-import Header from "../components/layout/Header";
+import Layout from "../components/layout/Layout";
 import SectionContainer from "../components/common/SectionContainer";
 import CreateTeamModal from "../components/teams/CreateTeamModal";
 import { useState } from "react";
@@ -30,93 +29,85 @@ const MyPage = () => {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* 사이드바 */}
-      <Sidebar onCreateTeam={() => setIsModalOpen(true)} />
+    <Layout
+      sidebarProps={{
+        onCreateTeam: () => setIsModalOpen(true),
+      }}
+      headerProps={{ showMyPageLink: false }}
+    >
+      <h1 className="text-2xl font-bold text-gray-900 mb-8">마이페이지</h1>
 
-      {/* 메인 영역 */}
-      <div className="flex-1 flex flex-col">
-        <Header showMyPageLink={false} />
+      <div className="max-w-4xl space-y-8">
+        {/* 유저 정보 섹션 */}
+        <SectionContainer title="내 정보">
+          <div className="space-y-3">
+            <div className="flex justify-between items-center">
+              <span className="text-gray-600">닉네임</span>
+              <span className="font-medium text-gray-900">
+                {user?.nickname || "-"}
+              </span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-gray-600">이메일</span>
+              <span className="text-gray-900">{user?.email || "-"}</span>
+            </div>
+          </div>
+        </SectionContainer>
 
-        {/* 컨텐츠 */}
-        <main className="flex-1 p-8 overflow-auto">
-          <h1 className="text-2xl font-bold text-gray-900 mb-8">마이페이지</h1>
-
-          <div className="max-w-4xl space-y-8">
-            {/* 유저 정보 섹션 */}
-            <SectionContainer title="내 정보">
-              <div className="space-y-3">
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-600">닉네임</span>
-                  <span className="font-medium text-gray-900">
-                    {user?.nickname || "-"}
-                  </span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-600">이메일</span>
-                  <span className="text-gray-900">{user?.email || "-"}</span>
-                </div>
-              </div>
-            </SectionContainer>
-
-            {/* 가입된 팀 목록 섹션 */}
-            <SectionContainer title={`가입된 팀 (${teams.length}개)`}>
-              {teams.length === 0 ? (
-                <p className="text-sm text-gray-400 py-2">
-                  가입된 팀이 없습니다.
-                </p>
-              ) : (
-                <div className="space-y-1">
-                  {teams.map((team) => (
-                    <div
-                      key={team.teamUuid}
-                      className="flex items-center justify-between py-3 cursor-pointer hover:bg-gray-50 rounded-lg px-2 -mx-2 transition-colors"
-                      onClick={() => navigate(`/team/${team.teamUuid}`)}
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
-                          <Users className="w-5 h-5 text-gray-500" />
-                        </div>
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <span className="font-medium text-gray-900">
-                              {team.teamName}
-                            </span>
-                            {team.role === "owner" && (
-                              <span className="flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-600 rounded-full text-xs font-medium">
-                                <Crown className="w-3 h-3" />
-                                owner
-                              </span>
-                            )}
-                            {team.role === "member" && (
-                              <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs font-medium">
-                                member
-                              </span>
-                            )}
-                          </div>
-                        </div>
+        {/* 가입된 팀 목록 섹션 */}
+        <SectionContainer title={`가입된 팀 (${teams.length}개)`}>
+          {teams.length === 0 ? (
+            <p className="text-sm text-gray-400 py-2">가입된 팀이 없습니다.</p>
+          ) : (
+            <div className="space-y-1">
+              {teams.map((team) => (
+                <div
+                  key={team.teamUuid}
+                  className="flex items-center justify-between py-3 cursor-pointer hover:bg-gray-50 rounded-lg px-2 -mx-2 transition-colors"
+                  onClick={() => navigate(`/team/${team.teamUuid}`)}
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
+                      <Users className="w-5 h-5 text-gray-500" />
+                    </div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-gray-900">
+                          {team.teamName}
+                        </span>
+                        {team.role === "owner" && (
+                          <span className="flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-600 rounded-full text-xs font-medium">
+                            <Crown className="w-3 h-3" />
+                            owner
+                          </span>
+                        )}
+                        {team.role === "member" && (
+                          <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs font-medium">
+                            member
+                          </span>
+                        )}
                       </div>
                     </div>
-                  ))}
+                  </div>
                 </div>
-              )}
-            </SectionContainer>
+              ))}
+            </div>
+          )}
+        </SectionContainer>
 
-            {/* 회원 탈퇴 섹션 */}
-            <SectionContainer
-              title="회원 탈퇴"
-              subtitle="계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다."
-            >
-              <button
-                onClick={handleWithdraw}
-                className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"
-              >
-                <UserX className="w-4 h-4" />
-                회원 탈퇴
-              </button>
-            </SectionContainer>
-          </div>
-        </main>
+        {/* 회원 탈퇴 섹션 */}
+        <SectionContainer
+          title="회원 탈퇴"
+          subtitle="계정을 삭제하면 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다."
+        >
+          <button
+            onClick={handleWithdraw}
+            className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"
+          >
+            <UserX className="w-4 h-4" />
+            회원 탈퇴
+          </button>
+        </SectionContainer>
       </div>
 
       {/* 팀 만들기 모달 */}
@@ -128,7 +119,7 @@ const MyPage = () => {
           setIsModalOpen(false);
         }}
       />
-    </div>
+    </Layout>
   );
 };
 

--- a/apps/frontend/src/pages/MyTeams.tsx
+++ b/apps/frontend/src/pages/MyTeams.tsx
@@ -1,22 +1,15 @@
 import { useState } from "react";
-import { LogOut, Users, Crown, Key } from "lucide-react";
+import { Users, Crown, Key } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
-import Sidebar from "../components/layout/Sidebar";
+import Layout from "../components/layout/Layout";
 import CreateTeamModal from "../components/teams/CreateTeamModal";
 import type { Team } from "../types";
 import { useTeams } from "../contexts/TeamContext";
 
 const MyTeams = () => {
   const navigate = useNavigate();
-  const { user, logout } = useAuth();
   const { teams, loading, addTeam } = useTeams();
   const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const handleLogout = async () => {
-    await logout();
-    navigate("/login");
-  };
 
   const handleTeamCreated = (newTeam: Team) => {
     // 팀 목록에 새 팀 추가
@@ -29,99 +22,84 @@ const MyTeams = () => {
   };
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* 사이드바 */}
-      <Sidebar onCreateTeam={() => setIsModalOpen(true)} />
+    <Layout
+      sidebarProps={{
+        onCreateTeam: () => setIsModalOpen(true),
+      }}
+      headerProps={{
+        extraButtons: (
+          <button
+            onClick={() => navigate("/oauth-apps")}
+            className="flex items-center gap-2 px-3 py-1.5 text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors cursor-pointer"
+          >
+            <Key className="w-4 h-4" />
+            <span className="text-sm">OAuth 연결</span>
+          </button>
+        ),
+      }}
+    >
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">내 팀</h1>
 
-      {/* 메인 영역 */}
-      <div className="flex-1 flex flex-col">
-        {/* 헤더 */}
-        <header className="h-14 bg-white border-b border-gray-200 px-6 flex items-center justify-end">
-          <div className="flex items-center gap-3">
-            {/* 사용자 이름 - 마이페이지 링크 */}
+      {loading ? (
+        <div className="flex items-center justify-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      ) : teams.length === 0 ? (
+        // 팀이 없을 때
+        <div className="bg-white rounded-xl border border-gray-200 p-12">
+          <div className="flex flex-col items-center justify-center text-center">
+            <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+              <Users className="w-8 h-8 text-gray-400" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">
+              가입한 팀이 없습니다
+            </h2>
+            <p className="text-sm text-gray-500 mb-6">
+              새로운 팀을 만들거나 기존 팀에 가입하여 시작하세요
+            </p>
             <button
-              onClick={() => navigate("/my-page")}
-              className="text-sm font-medium text-gray-700 hover:text-gray-900 cursor-pointer"
+              onClick={() => setIsModalOpen(true)}
+              className="px-6 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium cursor-pointer"
             >
-              {user?.nickname || user?.email?.split("@")[0]}
-            </button>
-
-            {/* OAuth 연결하기 버튼 */}
-            <button
-              onClick={() => navigate("/oauth-apps")}
-              className="flex items-center gap-2 px-3 py-1.5 text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors cursor-pointer"
-            >
-              <Key className="w-4 h-4" />
-              <span className="text-sm">OAuth 연결</span>
-            </button>
-
-            {/* 로그아웃 */}
-            <button
-              onClick={handleLogout}
-              className="flex items-center gap-2 px-3 py-1.5 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
-            >
-              <LogOut className="w-4 h-4" />
-              <span className="text-sm">로그아웃</span>
+              팀 만들기
             </button>
           </div>
-        </header>
-
-        {/* 컨텐츠 */}
-        <main className="flex-1 p-8 overflow-auto">
-          <h1 className="text-2xl font-bold text-gray-900 mb-6">내 팀</h1>
-
-          {loading ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
-            </div>
-          ) : teams.length === 0 ? (
-            // 팀이 없을 때
-            <div className="bg-white rounded-xl border border-gray-200 p-12">
-              <div className="flex flex-col items-center justify-center text-center">
-                <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
-                  <Users className="w-8 h-8 text-gray-400" />
+        </div>
+      ) : (
+        // 팀 목록
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {teams.map((team) => (
+            <button
+              key={team.teamUuid}
+              onClick={() => handleTeamClick(team)}
+              className="bg-white rounded-xl border border-gray-200 p-6 text-left hover:border-blue-300 hover:shadow-md transition-all cursor-pointer relative"
+            >
+              {team.role === "owner" && (
+                <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 bg-amber-50 text-amber-600 rounded-full">
+                  <Crown className="w-3 h-3" />
+                  <span className="text-xs font-medium">Owner</span>
                 </div>
-                <h2 className="text-lg font-semibold text-gray-900 mb-2">가입한 팀이 없습니다</h2>
-                <p className="text-sm text-gray-500 mb-6">새로운 팀을 만들거나 기존 팀에 가입하여 시작하세요</p>
-                <button
-                  onClick={() => setIsModalOpen(true)}
-                  className="px-6 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium cursor-pointer"
-                >
-                  팀 만들기
-                </button>
+              )}
+              <div className="flex items-center gap-3 mb-3 pr-16">
+                <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center shrink-0">
+                  <Users className="w-5 h-5 text-blue-600" />
+                </div>
+                <h3 className="font-semibold text-gray-900 wrap-break-word min-w-0">
+                  {team.teamName}
+                </h3>
               </div>
-            </div>
-          ) : (
-            // 팀 목록
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {teams.map((team) => (
-                <button
-                  key={team.teamUuid}
-                  onClick={() => handleTeamClick(team)}
-                  className="bg-white rounded-xl border border-gray-200 p-6 text-left hover:border-blue-300 hover:shadow-md transition-all cursor-pointer relative"
-                >
-                  {team.role === "owner" && (
-                    <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-1 bg-amber-50 text-amber-600 rounded-full">
-                      <Crown className="w-3 h-3" />
-                      <span className="text-xs font-medium">Owner</span>
-                    </div>
-                  )}
-                  <div className="flex items-center gap-3 mb-3 pr-16">
-                    <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center shrink-0">
-                      <Users className="w-5 h-5 text-blue-600" />
-                    </div>
-                    <h3 className="font-semibold text-gray-900 wrap-break-word min-w-0">{team.teamName}</h3>
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-        </main>
-      </div>
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* 팀 만들기 모달 */}
-      <CreateTeamModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} onTeamCreated={handleTeamCreated} />
-    </div>
+      <CreateTeamModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onTeamCreated={handleTeamCreated}
+      />
+    </Layout>
   );
 };
 

--- a/apps/frontend/src/pages/SettingPage.tsx
+++ b/apps/frontend/src/pages/SettingPage.tsx
@@ -9,8 +9,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { useTeams } from "../contexts/TeamContext";
 import { teamApi } from "../services/api";
 import { Users, Copy, LogOut, Check, Crown, Plus, Trash2 } from "lucide-react";
-import Sidebar from "../components/layout/Sidebar";
-import Header from "../components/layout/Header";
+import Layout from "../components/layout/Layout";
 import CreateTeamModal from "../components/teams/CreateTeamModal";
 import SectionContainer from "../components/common/SectionContainer";
 
@@ -221,258 +220,244 @@ const SettingPage = () => {
   const isAdmin = currentTeam?.role === "owner";
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* 사이드바 */}
-      <Sidebar onCreateTeam={() => setIsModalOpen(true)} />
+    <Layout
+      sidebarProps={{
+        onCreateTeam: () => setIsModalOpen(true),
+      }}
+    >
+      <h1 className="text-2xl font-bold text-gray-900 mb-8">팀 설정</h1>
 
-      {/* 메인 영역 */}
-      <div className="flex-1 flex flex-col">
-        <Header />
-
-        {/* 컨텐츠 */}
-        <main className="flex-1 p-8 overflow-auto">
-          <h1 className="text-2xl font-bold text-gray-900 mb-8">팀 설정</h1>
-
-          <div className="max-w-4xl space-y-8">
-            {/* 팀 정보 섹션 */}
-            <SectionContainer title="팀 정보">
-              <div className="space-y-3">
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-600">팀 이름</span>
-                  <span className="font-medium text-gray-900">
-                    {currentTeam?.teamName}
-                  </span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-600">생성일</span>
-                  <span className="text-gray-900">
-                    {currentTeam?.createdAt &&
-                      formatDate(currentTeam.createdAt)}
-                  </span>
-                </div>
-              </div>
-            </SectionContainer>
-
-            {/* 멤버 목록 섹션 */}
-            <SectionContainer
-              title={`팀원 (${members.length}명)`}
-              headerAction={
-                <button
-                  onClick={handleCopyInviteLink}
-                  className={`flex items-center justify-center gap-2 px-3 py-1.5 text-sm min-w-[120px] rounded-lg transition-colors cursor-pointer ${
-                    copied
-                      ? "text-blue-600 border border-blue-300 bg-blue-50"
-                      : "text-blue-600 border border-blue-200 hover:bg-blue-50"
-                  }`}
-                >
-                  {copied ? (
-                    <>
-                      <Check className="w-4 h-4" />
-                      <span>복사됨!</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="w-4 h-4" />
-                      <span>초대 링크 복사</span>
-                    </>
-                  )}
-                </button>
-              }
-            >
-              <div className="space-y-1">
-                {members.map((member) => (
-                  <div
-                    key={member.userUuid}
-                    className="flex items-center justify-between py-3"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
-                        <Users className="w-5 h-5 text-gray-500" />
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium text-gray-900">
-                            {member.userName}
-                          </span>
-                          {member.role === "owner" && (
-                            <span className="flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-600 rounded-full text-xs font-medium">
-                              <Crown className="w-3 h-3" />
-                              owner
-                            </span>
-                          )}
-                          {member.userUuid === user?.uuid && (
-                            <span className="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs font-medium">
-                              me
-                            </span>
-                          )}
-                        </div>
-                        <span className="text-sm text-gray-500">
-                          {member.userEmail}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </SectionContainer>
-
-            {/* 토큰 사용량 섹션 */}
-            {tokenUsage && (
-              <SectionContainer title="AI 사용량">
-                <div className="space-y-3">
-                  <div className="flex justify-between items-center">
-                    <span className="text-gray-600">오늘 사용량</span>
-                  </div>
-                  {/* 프로그레스 바 */}
-                  <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-blue-600 rounded-full transition-all"
-                      style={{ width: `${tokenUsage.percentage}%` }}
-                    />
-                  </div>
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm text-gray-500">
-                      매일 자정(KST)에 초기화됩니다
-                    </span>
-                    <span className="text-sm font-medium text-blue-600">
-                      {tokenUsage.percentage}% 사용
-                    </span>
-                  </div>
-                </div>
-              </SectionContainer>
-            )}
-
-            {/* 웹훅 관리 섹션 */}
-            <SectionContainer
-              title="웹훅 관리"
-              badge={isAdmin ? "Owner" : undefined}
-              subtitle="팀 내 이벤트 발생 시 데이터를 전송할 URL을 관리합니다."
-            >
-              {/* 웹훅 목록 */}
-              <div className="space-y-3 mb-4">
-                {webhooks.length === 0 ? (
-                  <p className="text-sm text-gray-400 py-2">
-                    등록된 웹훅이 없습니다.
-                  </p>
-                ) : (
-                  webhooks.map((webhook) => (
-                    <div
-                      key={webhook.webhookUuid}
-                      className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg"
-                    >
-                      {/* 토글 스위치 - owner만 클릭 가능 */}
-                      {isAdmin ? (
-                        <button
-                          onClick={() => handleToggleWebhook(webhook)}
-                          className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                            webhook.isActive ? "bg-blue-600" : "bg-gray-300"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
-                              webhook.isActive
-                                ? "translate-x-5"
-                                : "translate-x-0"
-                            }`}
-                          />
-                        </button>
-                      ) : (
-                        <div
-                          className={`relative w-11 h-6 rounded-full ${
-                            webhook.isActive ? "bg-blue-600" : "bg-gray-300"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full ${
-                              webhook.isActive
-                                ? "translate-x-5"
-                                : "translate-x-0"
-                            }`}
-                          />
-                        </div>
-                      )}
-
-                      {/* URL */}
-                      <span className="flex-1 text-sm text-gray-700 truncate">
-                        {webhook.url}
-                      </span>
-
-                      {/* 삭제 버튼 - owner만 표시 */}
-                      {isAdmin && (
-                        <button
-                          onClick={() =>
-                            handleDeleteWebhook(webhook.webhookUuid)
-                          }
-                          className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors cursor-pointer"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
-                  ))
-                )}
-              </div>
-
-              {/* 웹훅 추가 - owner만 표시 */}
-              {isAdmin &&
-                (showWebhookInput ? (
-                  <div className="flex gap-2">
-                    <input
-                      type="url"
-                      value={webhookUrl}
-                      onChange={(e) => setWebhookUrl(e.target.value)}
-                      placeholder="https://전송받을-주소를-입력하세요..."
-                      className="flex-1 px-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      disabled={isAddingWebhook}
-                    />
-                    <button
-                      onClick={handleAddWebhook}
-                      disabled={!webhookUrl.trim() || isAddingWebhook}
-                      className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {isAddingWebhook ? "추가 중..." : "추가"}
-                    </button>
-                    <button
-                      onClick={() => {
-                        setShowWebhookInput(false);
-                        setWebhookUrl("");
-                      }}
-                      className="px-3 py-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
-                    >
-                      취소
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => setShowWebhookInput(true)}
-                    className="flex items-center gap-2 px-4 py-2 text-sm text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors cursor-pointer"
-                  >
-                    <Plus className="w-4 h-4" />
-                    웹훅 추가
-                  </button>
-                ))}
-            </SectionContainer>
-
-            {/* 팀 탈퇴 섹션 */}
-            <SectionContainer
-              title="팀 탈퇴"
-              subtitle={
-                isAdmin
-                  ? "관리자는 팀에서 탈퇴할 수 없습니다. 다른 멤버에게 관리자 권한을 넘긴 후 탈퇴해주세요."
-                  : "팀에서 탈퇴하면 더 이상 이 팀의 콘텐츠에 접근할 수 없습니다."
-              }
-            >
-              <button
-                onClick={handleLeaveTeam}
-                disabled={isAdmin || leaving}
-                className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <LogOut className="w-4 h-4" />
-                {leaving ? "탈퇴 중..." : "팀 탈퇴"}
-              </button>
-            </SectionContainer>
+      <div className="max-w-4xl space-y-8">
+        {/* 팀 정보 섹션 */}
+        <SectionContainer title="팀 정보">
+          <div className="space-y-3">
+            <div className="flex justify-between items-center">
+              <span className="text-gray-600">팀 이름</span>
+              <span className="font-medium text-gray-900">
+                {currentTeam?.teamName}
+              </span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="text-gray-600">생성일</span>
+              <span className="text-gray-900">
+                {currentTeam?.createdAt && formatDate(currentTeam.createdAt)}
+              </span>
+            </div>
           </div>
-        </main>
+        </SectionContainer>
+
+        {/* 멤버 목록 섹션 */}
+        <SectionContainer
+          title={`팀원 (${members.length}명)`}
+          headerAction={
+            <button
+              onClick={handleCopyInviteLink}
+              className={`flex items-center justify-center gap-2 px-3 py-1.5 text-sm min-w-[120px] rounded-lg transition-colors cursor-pointer ${
+                copied
+                  ? "text-blue-600 border border-blue-300 bg-blue-50"
+                  : "text-blue-600 border border-blue-200 hover:bg-blue-50"
+              }`}
+            >
+              {copied ? (
+                <>
+                  <Check className="w-4 h-4" />
+                  <span>복사됨!</span>
+                </>
+              ) : (
+                <>
+                  <Copy className="w-4 h-4" />
+                  <span>초대 링크 복사</span>
+                </>
+              )}
+            </button>
+          }
+        >
+          <div className="space-y-1">
+            {members.map((member) => (
+              <div
+                key={member.userUuid}
+                className="flex items-center justify-between py-3"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
+                    <Users className="w-5 h-5 text-gray-500" />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-900">
+                        {member.userName}
+                      </span>
+                      {member.role === "owner" && (
+                        <span className="flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-600 rounded-full text-xs font-medium">
+                          <Crown className="w-3 h-3" />
+                          owner
+                        </span>
+                      )}
+                      {member.userUuid === user?.uuid && (
+                        <span className="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs font-medium">
+                          me
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-sm text-gray-500">
+                      {member.userEmail}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </SectionContainer>
+
+        {/* 토큰 사용량 섹션 */}
+        {tokenUsage && (
+          <SectionContainer title="AI 사용량">
+            <div className="space-y-3">
+              <div className="flex justify-between items-center">
+                <span className="text-gray-600">오늘 사용량</span>
+              </div>
+              {/* 프로그레스 바 */}
+              <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-blue-600 rounded-full transition-all"
+                  style={{ width: `${tokenUsage.percentage}%` }}
+                />
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-sm text-gray-500">
+                  매일 자정(KST)에 초기화됩니다
+                </span>
+                <span className="text-sm font-medium text-blue-600">
+                  {tokenUsage.percentage}% 사용
+                </span>
+              </div>
+            </div>
+          </SectionContainer>
+        )}
+
+        {/* 웹훅 관리 섹션 */}
+        <SectionContainer
+          title="웹훅 관리"
+          badge={isAdmin ? "Owner" : undefined}
+          subtitle="팀 내 이벤트 발생 시 데이터를 전송할 URL을 관리합니다."
+        >
+          {/* 웹훅 목록 */}
+          <div className="space-y-3 mb-4">
+            {webhooks.length === 0 ? (
+              <p className="text-sm text-gray-400 py-2">
+                등록된 웹훅이 없습니다.
+              </p>
+            ) : (
+              webhooks.map((webhook) => (
+                <div
+                  key={webhook.webhookUuid}
+                  className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg"
+                >
+                  {/* 토글 스위치 - owner만 클릭 가능 */}
+                  {isAdmin ? (
+                    <button
+                      onClick={() => handleToggleWebhook(webhook)}
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                        webhook.isActive ? "bg-blue-600" : "bg-gray-300"
+                      }`}
+                    >
+                      <span
+                        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                          webhook.isActive ? "translate-x-5" : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  ) : (
+                    <div
+                      className={`relative w-11 h-6 rounded-full ${
+                        webhook.isActive ? "bg-blue-600" : "bg-gray-300"
+                      }`}
+                    >
+                      <span
+                        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full ${
+                          webhook.isActive ? "translate-x-5" : "translate-x-0"
+                        }`}
+                      />
+                    </div>
+                  )}
+
+                  {/* URL */}
+                  <span className="flex-1 text-sm text-gray-700 truncate">
+                    {webhook.url}
+                  </span>
+
+                  {/* 삭제 버튼 - owner만 표시 */}
+                  {isAdmin && (
+                    <button
+                      onClick={() => handleDeleteWebhook(webhook.webhookUuid)}
+                      className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors cursor-pointer"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* 웹훅 추가 - owner만 표시 */}
+          {isAdmin &&
+            (showWebhookInput ? (
+              <div className="flex gap-2">
+                <input
+                  type="url"
+                  value={webhookUrl}
+                  onChange={(e) => setWebhookUrl(e.target.value)}
+                  placeholder="https://전송받을-주소를-입력하세요..."
+                  className="flex-1 px-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  disabled={isAddingWebhook}
+                />
+                <button
+                  onClick={handleAddWebhook}
+                  disabled={!webhookUrl.trim() || isAddingWebhook}
+                  className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isAddingWebhook ? "추가 중..." : "추가"}
+                </button>
+                <button
+                  onClick={() => {
+                    setShowWebhookInput(false);
+                    setWebhookUrl("");
+                  }}
+                  className="px-3 py-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+                >
+                  취소
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowWebhookInput(true)}
+                className="flex items-center gap-2 px-4 py-2 text-sm text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors cursor-pointer"
+              >
+                <Plus className="w-4 h-4" />
+                웹훅 추가
+              </button>
+            ))}
+        </SectionContainer>
+
+        {/* 팀 탈퇴 섹션 */}
+        <SectionContainer
+          title="팀 탈퇴"
+          subtitle={
+            isAdmin
+              ? "관리자는 팀에서 탈퇴할 수 없습니다. 다른 멤버에게 관리자 권한을 넘긴 후 탈퇴해주세요."
+              : "팀에서 탈퇴하면 더 이상 이 팀의 콘텐츠에 접근할 수 없습니다."
+          }
+        >
+          <button
+            onClick={handleLeaveTeam}
+            disabled={isAdmin || leaving}
+            className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <LogOut className="w-4 h-4" />
+            {leaving ? "탈퇴 중..." : "팀 탈퇴"}
+          </button>
+        </SectionContainer>
       </div>
 
       {/* 팀 만들기 모달 */}
@@ -484,7 +469,7 @@ const SettingPage = () => {
           setIsModalOpen(false);
         }}
       />
-    </div>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
Closes #251 
Closes #255 

## 작업 내용

- 공통 Layout 컴포넌트를 추출하여 페이지 간 중복 코드 제거
- Header에 extraButtons prop 추가로 페이지별 커스텀 버튼 지원
- MyTeams, TeamPage, MyPage, SettingPage에 Layout 적용

#### Layout 컴포넌트 추가
- Sidebar + Header + main 영역을 하나의 컴포넌트로 통합
- sidebarProps, headerProps로 페이지별 설정 전달

#### Header에 extraButtons prop 추가
- 사용자 이름과 로그아웃 사이에 커스텀 버튼 삽입 가능
- MyTeams의 OAuth 연결 버튼에 활용

#### 페이지에 Layout 적용
- 각 페이지에서 중복된 Sidebar, Header 코드 제거
- MyPage: showMyPageLink: false 설정
- MyTeams: extraButtons로 OAuth 버튼 전달
- TeamPage: 폴더 관련 sidebarProps 전달