### PR TITLE
팀 owner 권한 위임 및 팀 삭제 기능 구현

### DIFF
--- a/apps/backend/src/teams/repositories/team.repository.ts
+++ b/apps/backend/src/teams/repositories/team.repository.ts
@@ -144,6 +144,25 @@ export class TeamRepository {
   }
 
   /**
+   * 소유권 이전 (트랜잭션으로 역할 교체)
+   * @param teamId 팀 pk
+   * @param fromUserId 현재 owner의 userId
+   * @param toUserId 새 owner가 될 userId
+   */
+  async transferOwnership(teamId: number, fromUserId: number, toUserId: number): Promise<void> {
+    await this.prisma.$transaction([
+      this.prisma.member.update({
+        where: { teamId_userId: { teamId, userId: toUserId } },
+        data: { role: "owner" },
+      }),
+      this.prisma.member.update({
+        where: { teamId_userId: { teamId, userId: fromUserId } },
+        data: { role: "member" },
+      }),
+    ]);
+  }
+
+  /**
    * 팀 멤버 수 조회
    * @param teamId 팀 pk
    * @returns 팀 멤버 수

--- a/apps/backend/src/teams/repositories/team.repository.ts
+++ b/apps/backend/src/teams/repositories/team.repository.ts
@@ -127,4 +127,49 @@ export class TeamRepository {
     });
     return member ? MemberMapper.fromPrisma(member) : null;
   }
+
+  /**
+   * 멤버 역할 업데이트
+   * @param teamId 팀 pk
+   * @param userId 유저 pk
+   * @param role 멤버 역할
+   * @returns 멤버 엔티티
+   */
+  async updateMemberRole(teamId: number, userId: number, role: string): Promise<Member> {
+    const updated = await this.prisma.member.update({
+      where: { teamId_userId: { teamId, userId } },
+      data: { role },
+    });
+    return MemberMapper.fromPrisma(updated);
+  }
+
+  /**
+   * 팀 멤버 수 조회
+   * @param teamId 팀 pk
+   * @returns 팀 멤버 수
+   */
+  async countMembers(teamId: number): Promise<number> {
+    return this.prisma.member.count({
+      where: { teamId },
+    });
+  }
+
+  /**
+   * 팀 삭제
+   * @param teamId 팀 pk
+   * @returns 팀 삭제 여부 (boolean)
+   */
+  async deleteTeam(teamId: number): Promise<boolean> {
+    try {
+      await this.prisma.team.delete({
+        where: { id: teamId },
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+        return false;
+      }
+      throw error;
+    }
+  }
 }

--- a/apps/backend/src/teams/teams.controller.ts
+++ b/apps/backend/src/teams/teams.controller.ts
@@ -186,7 +186,7 @@ export class TeamsController {
     await this.teamsService.deleteTeam(teamUuid, user.userId);
 
     return ResponseBuilder.success<Record<string, never>>()
-      .status(HttpStatus.OK)
+      .status(HttpStatus.NO_CONTENT)
       .message("팀이 성공적으로 삭제되었습니다.")
       .data({})
       .build();

--- a/apps/backend/src/teams/teams.controller.ts
+++ b/apps/backend/src/teams/teams.controller.ts
@@ -11,6 +11,7 @@ import {
   ParseUUIDPipe,
   Inject,
   type LoggerService,
+  Patch,
 } from "@nestjs/common";
 import { TeamsService } from "./teams.service";
 import { CreateTeamRequestDto } from "./dto/create-team.request.dto";
@@ -22,6 +23,7 @@ import type { AuthenticatedUser } from "../oidc/types/oidc.types";
 import { ResponseBuilder } from "../common/builders/response.builder";
 import { WINSTON_MODULE_NEST_PROVIDER } from "nest-winston";
 import { TokenUsageService } from "./token-usage.service";
+import type { TransferOwnershipRequest } from "@repo/api";
 
 @Controller("teams")
 export class TeamsController {
@@ -148,5 +150,45 @@ export class TeamsController {
     const usage = await this.tokenUsageService.getUsage(teamUuid);
 
     return ResponseBuilder.success().status(HttpStatus.OK).message("토큰 사용량을 조회했습니다").data(usage).build();
+  }
+
+  /**
+   * owner 권한 위임
+   * PATCH /teams/:teamUuid/transfer-ownership
+   */
+  @Patch(":teamUuid/transfer-ownership")
+  @UseGuards(OidcGuard)
+  async transferOwnership(
+    @Param("teamUuid", ParseUUIDPipe) teamUuid: string,
+    @Body() dto: TransferOwnershipRequest,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    this.logger.log(`PATCH /teams/${teamUuid}/transfer-ownership`);
+
+    await this.teamsService.transferOwnership(teamUuid, user.userId, dto.targetUserUuid);
+
+    return ResponseBuilder.success<Record<string, never>>()
+      .status(HttpStatus.OK)
+      .message("팀 소유권이 성공적으로 위임되었습니다.")
+      .data({})
+      .build();
+  }
+
+  /**
+   * 팀 삭제
+   * DELETE /teams/:teamUuid/delete
+   */
+  @Delete(":teamUuid/delete")
+  @UseGuards(OidcGuard)
+  async deleteTeam(@Param("teamUuid", ParseUUIDPipe) teamUuid: string, @CurrentUser() user: AuthenticatedUser) {
+    this.logger.log(`DELETE /teams/${teamUuid}/delete`);
+
+    await this.teamsService.deleteTeam(teamUuid, user.userId);
+
+    return ResponseBuilder.success<Record<string, never>>()
+      .status(HttpStatus.OK)
+      .message("팀이 성공적으로 삭제되었습니다.")
+      .data({})
+      .build();
   }
 }

--- a/apps/backend/src/teams/teams.module.ts
+++ b/apps/backend/src/teams/teams.module.ts
@@ -9,11 +9,20 @@ import { UserModule } from "../user/user.module";
 import { TeamMemberGuard } from "./team-member.guard";
 import { TokenUsageRepository } from "./repositories/token-usage.repository";
 import { TokenUsageService } from "./token-usage.service";
+import { UserRepository } from "src/user/user.repository";
 
 @Module({
   imports: [DatabaseModule, OidcModule, UserModule],
   controllers: [TeamsController],
-  providers: [TeamsService, TeamRepository, TeamMemberGuard, FolderRepository, TokenUsageRepository, TokenUsageService],
+  providers: [
+    TeamsService,
+    TeamRepository,
+    TeamMemberGuard,
+    FolderRepository,
+    UserRepository,
+    TokenUsageRepository,
+    TokenUsageService,
+  ],
   exports: [TeamsService, TeamMemberGuard, TeamRepository, TokenUsageService],
 })
 export class TeamsModule {}

--- a/apps/backend/src/teams/teams.service.ts
+++ b/apps/backend/src/teams/teams.service.ts
@@ -173,9 +173,8 @@ export class TeamsService {
       throw new NotFoundException("대상 사용자가 팀에 소속되어 있지 않습니다.");
     }
 
-    // 역할 교체
-    await this.teamRepository.updateMemberRole(team.teamId, targetUser.userId, TeamRole.OWNER);
-    await this.teamRepository.updateMemberRole(team.teamId, currentUserId, TeamRole.MEMBER);
+    // 역할 교체 (트랜잭션으로 원자적 처리)
+    await this.teamRepository.transferOwnership(team.teamId, currentUserId, targetUser.userId);
   }
 
   /**

--- a/apps/backend/src/teams/teams.service.ts
+++ b/apps/backend/src/teams/teams.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   ForbiddenException,
   InternalServerErrorException,
+  BadRequestException,
 } from "@nestjs/common";
 import { TeamRepository } from "./repositories/team.repository";
 import { FolderRepository } from "../folders/repositories/folder.repository";
@@ -11,12 +12,14 @@ import { TeamRole } from "./constants/team-role.constants";
 import { DEFAULT_FOLDER_NAME } from "../folders/constants/folder.constants";
 import { TeamResponseDto, TeamPreviewResponseDto, TeamJoinResponseDto } from "./dto/team.response.dto";
 import { TeamMemberResponseDto } from "./dto/team-member.response.dto";
+import { UserRepository } from "src/user/user.repository";
 
 @Injectable()
 export class TeamsService {
   constructor(
     private readonly teamRepository: TeamRepository,
     private readonly folderRepository: FolderRepository,
+    private readonly userRepository: UserRepository,
   ) {}
 
   /**
@@ -132,5 +135,75 @@ export class TeamsService {
 
     const members = await this.teamRepository.findMembersByTeamId(team.teamId);
     return members.map(({ member, user }) => TeamMemberResponseDto.from(member, user));
+  }
+
+  /**
+   * 팀 소유권 위임
+   * @param teamUuid 팀UUID
+   * @param currentUserId 요청한 사용자ID
+   * @param targetUserUuid 권한 위임받을 사용자UUID
+   * @returns
+   */
+  async transferOwnership(teamUuid: string, currentUserId: number, targetUserUuid: string): Promise<void> {
+    const team = await this.teamRepository.findByUuid(teamUuid);
+    if (!team) {
+      throw new NotFoundException("해당 팀을 찾을 수 없습니다.");
+    }
+
+    // 현재 사용자가 owner인지 확인
+    const currentMember = await this.teamRepository.findMember(team.teamId, currentUserId);
+    if (!currentMember || currentMember.role !== TeamRole.OWNER) {
+      throw new ForbiddenException("팀 소유자만 권한을 위임할 수 있습니다.");
+    }
+
+    // 대상 사용자 조회
+    const targetUser = await this.userRepository.findByUuid(targetUserUuid);
+    if (!targetUser) {
+      throw new NotFoundException("대상 사용자를 찾을 수 없습니다.");
+    }
+
+    // 자기 자신에게 위임 불가
+    if (currentUserId === targetUser.userId) {
+      throw new BadRequestException("자기 자신에게 권한을 위임할 수 없습니다.");
+    }
+
+    // 대상이 팀 멤버인지 확인
+    const targetMember = await this.teamRepository.findMember(team.teamId, targetUser.userId);
+    if (!targetMember) {
+      throw new NotFoundException("대상 사용자가 팀에 소속되어 있지 않습니다.");
+    }
+
+    // 역할 교체
+    await this.teamRepository.updateMemberRole(team.teamId, targetUser.userId, TeamRole.OWNER);
+    await this.teamRepository.updateMemberRole(team.teamId, currentUserId, TeamRole.MEMBER);
+  }
+
+  /**
+   * 팀 삭제 (owner가 혼자일 때만)
+   */
+  async deleteTeam(teamUuid: string, userId: number): Promise<void> {
+    const team = await this.teamRepository.findByUuid(teamUuid);
+    if (!team) {
+      throw new NotFoundException("해당 팀을 찾을 수 없습니다.");
+    }
+
+    // owner 권한 확인
+    const member = await this.teamRepository.findMember(team.teamId, userId);
+    if (!member || member.role !== TeamRole.OWNER) {
+      throw new ForbiddenException("팀 소유자만 팀을 삭제할 수 있습니다.");
+    }
+
+    // 팀에 혼자인지 확인
+    const memberCount = await this.teamRepository.countMembers(team.teamId);
+    if (memberCount > 1) {
+      throw new ForbiddenException(
+        "다른 팀원이 있을 때는 팀을 삭제할 수 없습니다. 먼저 권한을 위임하거나 팀원이 탈퇴해야 합니다.",
+      );
+    }
+
+    const deleted = await this.teamRepository.deleteTeam(team.teamId);
+    if (!deleted) {
+      throw new InternalServerErrorException("팀 삭제 중 오류가 발생했습니다.");
+    }
   }
 }

--- a/apps/backend/src/user/user.repository.ts
+++ b/apps/backend/src/user/user.repository.ts
@@ -53,7 +53,11 @@ export class UserRepository {
 
     // 새 사용자 생성
     const created = await this.prisma.user.create({
-      data: data,
+      data: {
+        uuid: data.uuid,
+        nickname: data.nickname,
+        ...(data.email && { email: data.email }),
+      },
     });
     return UserMapper.fromPrisma(created);
   }

--- a/apps/frontend/src/components/setting/DeleteTeamModal.tsx
+++ b/apps/frontend/src/components/setting/DeleteTeamModal.tsx
@@ -46,7 +46,7 @@ export const DeleteTeamModal = ({
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
         onClick={onClose}
       />
-      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md">
         {/* Header */}
         <div className="flex items-center justify-between p-5 border-b border-gray-100">
           <div className="flex items-center gap-3">
@@ -65,14 +65,16 @@ export const DeleteTeamModal = ({
 
         {/* Body */}
         <div className="p-5">
-          <p className="text-gray-600 mb-2">
-            정말 이 팀을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
-          </p>
-          <p className="text-sm text-gray-500 mb-4">
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-sm text-red-800">
+              정말 이 팀을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+            </p>
+          </div>
+          <p className="text-sm text-gray-500 my-4">
             팀의 모든 폴더, 링크, 웹훅이 영구적으로 삭제됩니다.
           </p>
 
-          <div className="mb-4">
+          <div className="mb-6">
             <label className="block text-sm font-medium text-gray-700 mb-2">
               확인을 위해 팀 이름{" "}
               <span className="font-semibold text-red-600">"{teamName}"</span>을

--- a/apps/frontend/src/components/setting/DeleteTeamModal.tsx
+++ b/apps/frontend/src/components/setting/DeleteTeamModal.tsx
@@ -1,0 +1,115 @@
+import { useState, useRef } from "react";
+import { Trash2, X } from "lucide-react";
+import { teamApi } from "../../services/api";
+
+interface DeleteTeamModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  teamName: string;
+  teamUuid: string;
+  onSuccess: () => void;
+}
+
+export const DeleteTeamModal = ({
+  isOpen,
+  onClose,
+  teamName,
+  teamUuid,
+  onSuccess,
+}: DeleteTeamModalProps) => {
+  const [inputValue, setInputValue] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (!isOpen) return null;
+
+  const isConfirmed = inputValue === teamName;
+
+  const handleDelete = async () => {
+    if (!isConfirmed) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      await teamApi.deleteTeam(teamUuid);
+      onSuccess();
+    } catch {
+      setError("팀 삭제에 실패했습니다.");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-gray-100">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-red-100 rounded-xl flex items-center justify-center">
+              <Trash2 className="w-5 h-5 text-red-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">팀 삭제</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5">
+          <p className="text-gray-600 mb-2">
+            정말 이 팀을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+          </p>
+          <p className="text-sm text-gray-500 mb-4">
+            팀의 모든 폴더, 링크, 웹훅이 영구적으로 삭제됩니다.
+          </p>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              확인을 위해 팀 이름{" "}
+              <span className="font-semibold text-red-600">"{teamName}"</span>을
+              입력해주세요
+            </label>
+            <input
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder={teamName}
+              autoFocus
+              className="w-full px-4 py-2.5 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+              disabled={loading}
+            />
+          </div>
+
+          {error && <p className="text-xs text-red-500 mb-4">{error}</p>}
+
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              disabled={loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleDelete}
+              disabled={!isConfirmed || loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-red-600 rounded-xl hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "삭제 중..." : "팀 삭제"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/setting/DeleteTeamModal.tsx
+++ b/apps/frontend/src/components/setting/DeleteTeamModal.tsx
@@ -87,6 +87,12 @@ export const DeleteTeamModal = ({
               autoFocus
               className="w-full px-4 py-2.5 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
               disabled={loading}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleDelete();
+                }
+              }}
             />
           </div>
 

--- a/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
+++ b/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { Crown, X } from "lucide-react";
+import { Crown, X, Check } from "lucide-react";
 import { teamApi } from "../../services/api";
 import type { GetTeamMembersResponseData } from "@repo/api";
 
 interface TransferOwnershipModalProps {
   isOpen: boolean;
   onClose: () => void;
-  targetMember: GetTeamMembersResponseData | null;
+  members: GetTeamMembersResponseData[]; // 전체 멤버 (owner 제외하고 넘겨주기)
   teamUuid: string;
   onSuccess: () => void;
 }
@@ -14,20 +14,24 @@ interface TransferOwnershipModalProps {
 export const TransferOwnershipModal = ({
   isOpen,
   onClose,
-  targetMember,
+  members,
   teamUuid,
   onSuccess,
 }: TransferOwnershipModalProps) => {
+  const [selectedMember, setSelectedMember] =
+    useState<GetTeamMembersResponseData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  if (!isOpen || !targetMember) return null;
+  if (!isOpen) return null;
 
   const handleTransfer = async () => {
+    if (!selectedMember) return;
+
     try {
       setLoading(true);
       setError(null);
-      await teamApi.transferOwnership(teamUuid, targetMember.userUuid);
+      await teamApi.transferOwnership(teamUuid, selectedMember.userUuid);
       onSuccess();
       onClose();
     } catch {
@@ -37,13 +41,19 @@ export const TransferOwnershipModal = ({
     }
   };
 
+  const handleClose = () => {
+    setSelectedMember(null);
+    setError(null);
+    onClose();
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-        onClick={onClose}
+        onClick={handleClose}
       />
-      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md">
         {/* Header */}
         <div className="flex items-center justify-between p-5 border-b border-gray-100">
           <div className="flex items-center gap-3">
@@ -53,7 +63,7 @@ export const TransferOwnershipModal = ({
             <h2 className="text-lg font-semibold text-gray-900">권한 위임</h2>
           </div>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
           >
             <X className="w-4 h-4" />
@@ -62,21 +72,72 @@ export const TransferOwnershipModal = ({
 
         {/* Body */}
         <div className="p-5">
-          <p className="text-gray-600 mb-4">
-            <span className="font-semibold text-gray-900">
-              {targetMember.userName}
-            </span>
-            님에게 팀 관리자 권한을 위임하시겠습니까?
+          {/* 주의사항 */}
+          <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+            <p className="text-[13px] text-amber-800">
+              권한을 위임하면 본인은 일반 멤버가 되며, 팀 설정 권한을 잃게
+              됩니다.
+            </p>
+          </div>
+
+          {/* 팀원 선택 안내 */}
+          <p className="text-sm text-gray-600 mb-3">
+            권한을 위임할 팀원을 선택하세요
           </p>
-          <p className="text-sm text-gray-500 mb-5">
-            권한을 위임하면 본인은 일반 멤버가 되며, 팀 설정 권한을 잃게 됩니다.
+
+          {/* 팀원 목록 (스크롤) */}
+          <div className="max-h-48 overflow-y-auto border border-gray-200 rounded-lg mb-4">
+            {members.length === 0 ? (
+              <p className="p-4 text-sm text-gray-400 text-center">
+                위임할 수 있는 팀원이 없습니다.
+              </p>
+            ) : (
+              members.map((member) => (
+                <button
+                  key={member.userUuid}
+                  onClick={() => setSelectedMember(member)}
+                  className={`w-full flex items-center justify-between p-3 hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-b-0 ${
+                    selectedMember?.userUuid === member.userUuid
+                      ? "bg-amber-50"
+                      : ""
+                  }`}
+                >
+                  <div className="flex flex-col items-start">
+                    <span className="font-medium text-gray-900">
+                      {member.userName}
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {member.userEmail}
+                    </span>
+                  </div>
+                  {selectedMember?.userUuid === member.userUuid && (
+                    <Check className="w-5 h-5 text-amber-600" />
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+
+          {/* 선택된 멤버 확인 */}
+          <p className="text-sm text-gray-700 mb-4 h-5">
+            {selectedMember ? (
+              <>
+                <span className="font-semibold text-gray-900">
+                  {selectedMember.userName}
+                </span>
+                님에게 권한을 위임하시겠습니까?
+              </>
+            ) : (
+              <span className="text-gray-400">팀원을 선택해주세요</span>
+            )}
           </p>
 
           {error && <p className="text-xs text-red-500 mb-4">{error}</p>}
 
+          {/* 버튼 */}
           <div className="flex gap-2">
             <button
-              onClick={onClose}
+              onClick={handleClose}
               disabled={loading}
               className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors disabled:opacity-50"
             >
@@ -84,8 +145,8 @@ export const TransferOwnershipModal = ({
             </button>
             <button
               onClick={handleTransfer}
-              disabled={loading}
-              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-amber-600 rounded-xl hover:bg-amber-700 transition-colors disabled:opacity-50"
+              disabled={!selectedMember || loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-amber-600 rounded-xl hover:bg-amber-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading ? "위임 중..." : "권한 위임"}
             </button>

--- a/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
+++ b/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { Crown, X } from "lucide-react";
+import { teamApi } from "../../services/api";
+import type { GetTeamMembersResponseData } from "@repo/api";
+
+interface TransferOwnershipModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  targetMember: GetTeamMembersResponseData | null;
+  teamUuid: string;
+  onSuccess: () => void;
+}
+
+export const TransferOwnershipModal = ({
+  isOpen,
+  onClose,
+  targetMember,
+  teamUuid,
+  onSuccess,
+}: TransferOwnershipModalProps) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen || !targetMember) return null;
+
+  const handleTransfer = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      await teamApi.transferOwnership(teamUuid, targetMember.userUuid);
+      onSuccess();
+      onClose();
+    } catch {
+      setError("권한 위임에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-gray-100">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-amber-100 rounded-xl flex items-center justify-center">
+              <Crown className="w-5 h-5 text-amber-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">권한 위임</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5">
+          <p className="text-gray-600 mb-4">
+            <span className="font-semibold text-gray-900">
+              {targetMember.userName}
+            </span>
+            님에게 팀 관리자 권한을 위임하시겠습니까?
+          </p>
+          <p className="text-sm text-gray-500 mb-5">
+            권한을 위임하면 본인은 일반 멤버가 되며, 팀 설정 권한을 잃게 됩니다.
+          </p>
+
+          {error && <p className="text-xs text-red-500 mb-4">{error}</p>}
+
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              disabled={loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleTransfer}
+              disabled={loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-amber-600 rounded-xl hover:bg-amber-700 transition-colors disabled:opacity-50"
+            >
+              {loading ? "위임 중..." : "권한 위임"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/pages/SettingPage.tsx
+++ b/apps/frontend/src/pages/SettingPage.tsx
@@ -466,6 +466,12 @@ const SettingPage = () => {
                       placeholder="https://전송받을-주소를-입력하세요..."
                       className="flex-1 px-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       disabled={isAddingWebhook}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          handleAddWebhook();
+                        }
+                      }}
                     />
                     <button
                       onClick={handleAddWebhook}

--- a/apps/frontend/src/pages/SettingPage.tsx
+++ b/apps/frontend/src/pages/SettingPage.tsx
@@ -4,7 +4,7 @@ import type {
   GetTeamMembersResponseData,
   GetTeamWebhooksResponseData,
 } from "@repo/api";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { useTeams } from "../contexts/TeamContext";
 import { teamApi } from "../services/api";
@@ -52,6 +52,21 @@ const SettingPage = () => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [selectedMember, setSelectedMember] =
     useState<GetTeamMembersResponseData | null>(null);
+
+  const sortedMembers = useMemo(() => {
+    return [...members].sort((a, b) => {
+      const aIsMe = a.userUuid === user?.uuid;
+      const bIsMe = b.userUuid === user?.uuid;
+
+      if (aIsMe) return -1;
+      if (bIsMe) return 1;
+
+      if (a.role === "owner") return -1;
+      if (b.role === "owner") return 1;
+
+      return 0;
+    });
+  }, [members, user?.uuid]);
 
   // 팀 정보 및 멤버 조회
   useEffect(() => {
@@ -303,7 +318,7 @@ const SettingPage = () => {
               }
             >
               <div className="space-y-1">
-                {members.map((member) => (
+                {sortedMembers.map((member) => (
                   <div
                     key={member.userUuid}
                     className="flex items-center justify-between py-3"

--- a/apps/frontend/src/pages/SettingPage.tsx
+++ b/apps/frontend/src/pages/SettingPage.tsx
@@ -345,18 +345,109 @@ const SettingPage = () => {
                         <span className="text-sm text-gray-500">
                           {member.userEmail}
                         </span>
-                      )}
-                      {member.userUuid === user?.uuid && (
-                        <span className="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs font-medium">
-                          me
-                        </span>
-                      )}
+                      </div>
                     </div>
+                  </div>
+                ))}
+              </div>
+
+            </SectionContainer>
+
+            {/* 토큰 사용량 섹션 */}
+            {tokenUsage && (
+              <SectionContainer title="AI 사용량">
+                <div className="space-y-3">
+                  <div className="flex justify-between items-center">
+                    <span className="text-gray-600">오늘 사용량</span>
+                  </div>
+                  {/* 프로그레스 바 */}
+                  <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-blue-600 rounded-full transition-all"
+                      style={{ width: `${tokenUsage.percentage}%` }}
+                    />
+                  </div>
+                  <div className="flex justify-between items-center">
                     <span className="text-sm text-gray-500">
-                      {member.userEmail}
+                      매일 자정(KST)에 초기화됩니다
+                    </span>
+                    <span className="text-sm font-medium text-blue-600">
+                      {tokenUsage.percentage}% 사용
                     </span>
                   </div>
                 </div>
+              </SectionContainer>
+            )}
+
+            {/* 웹훅 관리 섹션 */}
+            <SectionContainer
+              title="웹훅 관리"
+              badge={isAdmin ? "Owner" : undefined}
+              subtitle="팀 내 이벤트 발생 시 데이터를 전송할 URL을 관리합니다."
+            >
+              {/* 웹훅 목록 */}
+              <div className="space-y-3 mb-4">
+                {webhooks.length === 0 ? (
+                  <p className="text-sm text-gray-400 py-2">
+                    등록된 웹훅이 없습니다.
+                  </p>
+                ) : (
+                  webhooks.map((webhook) => (
+                    <div
+                      key={webhook.webhookUuid}
+                      className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg"
+                    >
+                      {/* 토글 스위치 - owner만 클릭 가능 */}
+                      {isAdmin ? (
+                        <button
+                          onClick={() => handleToggleWebhook(webhook)}
+                          className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                            webhook.isActive ? "bg-blue-600" : "bg-gray-300"
+                          }`}
+                        >
+                          <span
+                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                              webhook.isActive
+                                ? "translate-x-5"
+                                : "translate-x-0"
+                            }`}
+                          />
+                        </button>
+                      ) : (
+                        <div
+                          className={`relative w-11 h-6 rounded-full ${
+                            webhook.isActive ? "bg-blue-600" : "bg-gray-300"
+                          }`}
+                        >
+                          <span
+                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full ${
+                              webhook.isActive
+                                ? "translate-x-5"
+                                : "translate-x-0"
+                            }`}
+                          />
+                        </div>
+                      )}
+
+                      {/* URL */}
+                      <span className="flex-1 text-sm text-gray-700 truncate">
+                        {webhook.url}
+                      </span>
+
+                      {/* 삭제 버튼 - owner만 표시 */}
+                      {isAdmin && (
+                        <button
+                          onClick={() =>
+                            handleDeleteWebhook(webhook.webhookUuid)
+                          }
+                          className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors cursor-pointer"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
+                  ))
+                )}
               </div>
 
               {/* 웹훅 추가 - owner만 표시 */}
@@ -378,43 +469,20 @@ const SettingPage = () => {
                       }}
                     />
                     <button
-                      onClick={() => handleToggleWebhook(webhook)}
-                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                        webhook.isActive ? "bg-blue-600" : "bg-gray-300"
-                      }`}
+                      onClick={handleAddWebhook}
+                      disabled={!webhookUrl.trim() || isAddingWebhook}
+                      className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      <span
-                        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
-                          webhook.isActive ? "translate-x-5" : "translate-x-0"
-                        }`}
-                      />
+                      {isAddingWebhook ? "추가 중..." : "추가"}
                     </button>
-                  ) : (
-                    <div
-                      className={`relative w-11 h-6 rounded-full ${
-                        webhook.isActive ? "bg-blue-600" : "bg-gray-300"
-                      }`}
-                    >
-                      <span
-                        className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full ${
-                          webhook.isActive ? "translate-x-5" : "translate-x-0"
-                        }`}
-                      />
-                    </div>
-                  )}
-
-                  {/* URL */}
-                  <span className="flex-1 text-sm text-gray-700 truncate">
-                    {webhook.url}
-                  </span>
-
-                  {/* 삭제 버튼 - owner만 표시 */}
-                  {isAdmin && (
                     <button
-                      onClick={() => handleDeleteWebhook(webhook.webhookUuid)}
-                      className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors cursor-pointer"
+                      onClick={() => {
+                        setShowWebhookInput(false);
+                        setWebhookUrl("");
+                      }}
+                      className="px-3 py-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
                     >
-                      <Trash2 className="w-4 h-4" />
+                      취소
                     </button>
                   </div>
                 ) : (

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -1,7 +1,11 @@
 import axios, { type InternalAxiosRequestConfig } from "axios";
 import axiosRetry from "axios-retry";
 import type { ApiResponse, Link, Folder, Team } from "../types";
-import { getStoredAccessToken, refreshAccessToken, clearTokens } from "./authentikAuth";
+import {
+  getStoredAccessToken,
+  refreshAccessToken,
+  clearTokens,
+} from "./authentikAuth";
 import type {
   GetTeamMembersResponseData,
   GetTeamTokenUsageResponseData,
@@ -84,7 +88,8 @@ api.interceptors.request.use((config) => {
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
-    const originalRequest: InternalAxiosRequestConfig | undefined = error.config;
+    const originalRequest: InternalAxiosRequestConfig | undefined =
+      error.config;
 
     if (
       error.response?.status === 401 &&
@@ -184,7 +189,10 @@ export const linkApi = {
   },
 
   // 태그로 검색
-  searchByTags: async (teamUuid: string, tags: string[]): Promise<ApiResponse<Link[]>> => {
+  searchByTags: async (
+    teamUuid: string,
+    tags: string[],
+  ): Promise<ApiResponse<Link[]>> => {
     return linkApi.getLinks({ teamUuid, tags });
   },
 };
@@ -205,13 +213,19 @@ export const folderApi = {
   },
 
   // POST /folders - 새 폴더 생성
-  createFolder: async (data: { teamUuid: string; folderName: string }): Promise<ApiResponse<Folder>> => {
+  createFolder: async (data: {
+    teamUuid: string;
+    folderName: string;
+  }): Promise<ApiResponse<Folder>> => {
     const response = await api.post("/folders", data);
     return response.data;
   },
 
   // PATCH /folders/:folderUuid - 폴더 이름 수정
-  updateFolder: async (folderUuid: string, data: { folderName: string }): Promise<ApiResponse<Folder>> => {
+  updateFolder: async (
+    folderUuid: string,
+    data: { folderName: string },
+  ): Promise<ApiResponse<Folder>> => {
     const response = await api.patch(`/folders/${folderUuid}`, data);
     return response.data;
   },
@@ -238,19 +252,25 @@ export const teamApi = {
   },
 
   // GET /teams/:teamUuid/preview - 초대 링크용 팀 정보 조회
-  getTeamPreview: async (teamUuid: string): Promise<ApiResponse<{ teamName: string }>> => {
+  getTeamPreview: async (
+    teamUuid: string,
+  ): Promise<ApiResponse<{ teamName: string }>> => {
     const response = await api.get(`/teams/${teamUuid}/preview`);
     return response.data;
   },
 
   // POST /teams/:teamUuid/join - 팀 가입
-  joinTeam: async (teamUuid: string): Promise<ApiResponse<JoinTeamResponseData>> => {
+  joinTeam: async (
+    teamUuid: string,
+  ): Promise<ApiResponse<JoinTeamResponseData>> => {
     const response = await api.post(`teams/${teamUuid}/join`);
     return response.data;
   },
 
   // GET /teams/:teamUuid/members - 팀 멤버 조회
-  getTeamMember: async (teamUuid: string): Promise<ApiResponse<GetTeamMembersResponseData>> => {
+  getTeamMember: async (
+    teamUuid: string,
+  ): Promise<ApiResponse<GetTeamMembersResponseData>> => {
     const response = await api.get(`teams/${teamUuid}/members`);
     return response.data;
   },
@@ -262,37 +282,49 @@ export const teamApi = {
 
   // ---------- webhook ---------
   // GET /teams/:teamUuid/webhooks - 팀에 등록된 웹훅 조회
-  getTeamWebhooks: async (teamUuid: string): Promise<ApiResponse<GetTeamWebhooksResponseData[]>> => {
+  getTeamWebhooks: async (
+    teamUuid: string,
+  ): Promise<ApiResponse<GetTeamWebhooksResponseData[]>> => {
     const response = await api.get(`teams/${teamUuid}/webhooks`);
     return response.data;
   },
 
   // POST /teams/:teamUuid/webhooks - 웹훅 등록
-  addTeamWebhooks: async (teamUuid: string, url: string): Promise<ApiResponse<GetTeamWebhooksResponseData>> => {
+  addTeamWebhooks: async (
+    teamUuid: string,
+    url: string,
+  ): Promise<ApiResponse<GetTeamWebhooksResponseData>> => {
     const response = await api.post(`teams/${teamUuid}/webhooks`, { url });
     return response.data;
   },
 
   // DELETE /teams/:teamUuid/webhooks/:webhookdUuid - 웹훅 삭제
-  deleteTeamWebhooks: async (teamUuid: string, webhookUuid: string): Promise<void> => {
+  deleteTeamWebhooks: async (
+    teamUuid: string,
+    webhookUuid: string,
+  ): Promise<void> => {
     await api.delete(`teams/${teamUuid}/webhooks/${webhookUuid}`);
   },
 
-  // PATCH /teams:teamUuid/webhooks/:webhookUuid/activate - 특정 훅을 활성화
+  // PATCH /teams/:teamUuid/webhooks/:webhookUuid/activate - 특정 훅을 활성화
   activateTeamWebhooks: async (
     teamUuid: string,
     webhookUuid: string,
   ): Promise<ApiResponse<GetTeamWebhooksResponseData>> => {
-    const response = await api.patch(`teams/${teamUuid}/webhooks/${webhookUuid}/activate`);
+    const response = await api.patch(
+      `teams/${teamUuid}/webhooks/${webhookUuid}/activate`,
+    );
     return response.data;
   },
 
-  // PATCH /teams:teamUuid/webhooks/:webhookUuid/deactivate - 특정 훅을 비활성화
+  // PATCH /teams/:teamUuid/webhooks/:webhookUuid/deactivate - 특정 훅을 비활성화
   deactivateTeamWebhooks: async (
     teamUuid: string,
     webhookUuid: string,
   ): Promise<ApiResponse<GetTeamWebhooksResponseData>> => {
-    const response = await api.patch(`teams/${teamUuid}/webhooks/${webhookUuid}/deactivate`);
+    const response = await api.patch(
+      `teams/${teamUuid}/webhooks/${webhookUuid}/deactivate`,
+    );
     return response.data;
   },
 
@@ -302,6 +334,22 @@ export const teamApi = {
   ): Promise<ApiResponse<GetTeamTokenUsageResponseData>> => {
     const response = await api.get(`teams/${teamUuid}/token-usage`);
     return response.data;
+  },
+
+  // PATCH /teams/:teamUuid/transfer-ownership - 오너 권한 위임
+  transferOwnership: async (
+    teamUuid: string,
+    targetUserUuid: string,
+  ): Promise<ApiResponse<Record<string, never>>> => {
+    const response = await api.patch(`teams/${teamUuid}/transfer-ownership`, {
+      targetUserUuid,
+    });
+    return response.data;
+  },
+
+  // DELETE /teams/:teamUuid/delete - 팀 삭제
+  deleteTeam: async (teamUuid: string): Promise<void> => {
+    await api.delete(`teams/${teamUuid}/delete`);
   },
 };
 
@@ -314,7 +362,9 @@ export const oauthAppsApi = {
   },
 
   // POST /oauth-apps - OAuth App 생성
-  createOAuthApp: async (data: CreateOAuthAppRequest): Promise<ApiResponse<OAuthAppCreatedResponseData>> => {
+  createOAuthApp: async (
+    data: CreateOAuthAppRequest,
+  ): Promise<ApiResponse<OAuthAppCreatedResponseData>> => {
     const response = await api.post("/oauth-apps", data);
     return response.data;
   },

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -340,11 +340,10 @@ export const teamApi = {
   transferOwnership: async (
     teamUuid: string,
     targetUserUuid: string,
-  ): Promise<ApiResponse<Record<string, never>>> => {
-    const response = await api.patch(`teams/${teamUuid}/transfer-ownership`, {
+  ): Promise<void> => {
+    await api.patch(`teams/${teamUuid}/transfer-ownership`, {
       targetUserUuid,
     });
-    return response.data;
   },
 
   // DELETE /teams/:teamUuid/delete - 팀 삭제

--- a/packages/api/src/teams/team.schema.ts
+++ b/packages/api/src/teams/team.schema.ts
@@ -46,3 +46,8 @@ export const GetTeamTokenUsageResponseDataSchema = z.object({
   maxTokens: z.number(),
   percentage: z.number(),
 });
+
+/** 권한 위임 요청 */
+export const TransferOwnershipRequestSchema = z.object({
+  targetUserUuid: z.string().uuid(),
+});

--- a/packages/api/src/teams/team.type.ts
+++ b/packages/api/src/teams/team.type.ts
@@ -7,6 +7,7 @@ import {
   JoinTeamResponseDataSchema,
   PreviewTeamRespondDataSchema,
   TeamResponseDataSchema,
+  TransferOwnershipRequestSchema,
 } from "./team.schema.js";
 
 export type CreateTeamRequest = z.infer<typeof CreateTeamRequestSchema>;
@@ -23,4 +24,7 @@ export type GetTeamWebhooksResponseData = z.infer<
 >;
 export type GetTeamTokenUsageResponseData = z.infer<
   typeof GetTeamTokenUsageResponseDataSchema
+>;
+export type TransferOwnershipRequest = z.infer<
+  typeof TransferOwnershipRequestSchema
 >;


### PR DESCRIPTION
Closes #227 

## 개요
- 팀 오너가 다른 멤버에게 권한을 위임하는 기능 추가
- 팀 오너가 팀을 삭제할 수 있는 기능 추가
- 멤버 목록 정렬 개선(본인 -> 오너 -> 나머지)

## 주요 변경사항
### 백엔드
- 권한 위임 api 추가 : `role=owner` 일 때 가능
- 팀 삭제 api 추가 : 팀원이 한 명 (본인만 존재) 일 때 가능

### 프론트엔드
- 권한 위임 모달 구현 : 모달 내 팀원 선택 가능
- 팀 삭제 모달 구현 : github처럼 팀 이름을 정확히 입력해야 삭제 가능
- 설정 페이지에 권한 위임 추가 : 팀의 오너일때만 보임
- 설정 페이지에 삭제 버튼 추가 : 팀의 오너이면서 팀원이 본인뿐일 때 팀 탈퇴 대신 삭제로
- 멤버 조회 시 본인/오너를 우선 정렬

**⬇️  팀의 오너일 때 `권한 위임` 버튼이 보임**
<img width="1409" height="853" alt="스크린샷 2026-02-04 오전 1 07 45" src="https://github.com/user-attachments/assets/198a1f16-934b-4dc2-b426-a25315571fb9" />

**⬇️  `권한 위임` 버튼을 눌렀을 때 열리는 모달** 
<img width="1037" height="686" alt="스크린샷 2026-02-04 오전 1 07 51" src="https://github.com/user-attachments/assets/bed9937f-8b75-434c-bb0c-dddc1c118ecd" />

**⬇️  권한을 위임할 유저를 골랐을 때 권한위임 버튼 활성화**
<img width="985" height="652" alt="스크린샷 2026-02-04 오전 1 07 58" src="https://github.com/user-attachments/assets/b3664541-b005-4176-8f30-4ab31c55a4f1" />

**⬇️  팀의 owner이면서 다른 팀원이 없으면 `팀 탈퇴` 대신 `팀 삭제` 버튼이 보임**
<img width="1395" height="856" alt="스크린샷 2026-02-04 오전 1 08 16" src="https://github.com/user-attachments/assets/36519dd0-8c7a-4a43-8d9a-265d52fc6f17" />

**⬇️  `팀 삭제`를 눌렀을 때 열리는 모달**
<img width="829" height="587" alt="스크린샷 2026-02-04 오전 1 24 53" src="https://github.com/user-attachments/assets/1730d13b-95b1-4cf2-b87a-0a670ab44bf8" />

**⬇️  팀 이름을 정확히 입력하면 팀 삭제 버튼 활성화**
<img width="906" height="580" alt="스크린샷 2026-02-04 오전 1 24 59" src="https://github.com/user-attachments/assets/5667e67d-67d9-4f8e-b33b-7f4224baff59" />

### 유의사항
추후에 서비스 탈퇴 연결 시 팀을 소유한 유저는 탈퇴 불가능하게 처리하거나 자동 위임 기능 추가
그렇지 않으면 팀이 사라질수도...
+점점 거대해지는 SettingPage.. 섹션별로 파일 나누겠습니다 🥶