### PR TITLE
토큰 갱신 로직 개선으로 10분 후 로그아웃 문제 해결

### DIFF
--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -10,7 +10,6 @@ import type { User } from "../types";
 import {
   startAuthentikLogin,
   clearTokens,
-  getStoredAccessToken,
   getValidAccessToken,
   getUserInfo,
   getAuthentikLogoutUrl,
@@ -55,17 +54,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   // 토큰이 만료되었으면 자동으로 refresh_token으로 갱신 시도
   const checkAuth = async () => {
     try {
-      // 저장된 토큰이 있는지 먼저 확인
-      const storedToken = getStoredAccessToken();
-
-      if (!storedToken) {
-        // 토큰 없음 - 로그인 필요
-        setUser(null);
-        setIsLoading(false);
-        return;
-      }
-
-      // 유효한 토큰 가져오기 (만료 시 자동 갱신)
+      // 유효한 토큰 가져오기 (access_token이 없거나 만료되었으면 refresh_token으로 갱신 시도)
       const accessToken = await getValidAccessToken();
 
       if (accessToken) {

--- a/apps/frontend/src/services/authentikAuth.ts
+++ b/apps/frontend/src/services/authentikAuth.ts
@@ -269,16 +269,17 @@ export async function refreshAccessToken(): Promise<TokenResponse | null> {
 export async function getValidAccessToken(): Promise<string | null> {
   const accessToken = getStoredAccessToken();
 
-  if (!accessToken) {
-    return null;
-  }
-
-  // 토큰이 만료되지 않았으면 그대로 반환
-  if (!isTokenExpired()) {
+  // 토큰이 있고 만료되지 않았으면 그대로 반환
+  if (accessToken && !isTokenExpired()) {
     return accessToken;
   }
 
-  // 토큰이 만료되었으면 갱신 시도
+  // 토큰이 없거나 만료되었으면 refresh_token으로 갱신 시도
+  const refreshToken = getStoredRefreshToken();
+  if (!refreshToken) {
+    return null;
+  }
+
   const newTokens = await refreshAccessToken();
 
   if (newTokens) {

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -5,6 +5,10 @@ resource "authentik_provider_oauth2" "teamstash" {
   client_id   = var.oauth_client_id
   client_type = "public"
 
+  # 토큰 유효기간 설정 추가
+  access_token_validity  = "hours=1" 
+  refresh_token_validity = "days=30"
+  
   authentication_flow = authentik_flow.teamstash_authentication_flow.uuid
   authorization_flow  = data.authentik_flow.default_authorization.id
   invalidation_flow   = authentik_flow.post_logout_redirect.uuid


### PR DESCRIPTION
Closes #241 

## 문제 원인
- 10분에 한 번씩 로그인이 풀리는 문제 발생
- 10분: authentik_provider_oauth2 리소스에 토큰 유효기간 설정이 없어서 authentik 기본값(10분)이 적용되고 있었음
- `getValidAccessToken()`이 access_token이 없으면 refresh 시도 없이 바로 null 반환
- 페이지 새로고침 시 access_token 쿠키가 만료되어 있으면 갱신 시도 없이 로그아웃 처리

## 해결
- `getValidAccessToken()`: access_token이 없거나 만료된 경우 refresh_token 존재 여부를 먼저 확인 후 갱신 시도
- `AuthContext.checkAuth()`: `getStoredAccessToken()` 사전 체크 제거, `getValidAccessToken()`만으로 통합
- `providers.tf`: access_token 유효기간을 10분 → 1시간으로 변경

⬇️ 한시간으로 토큰 유효기간 변경
<img width="924" height="321" alt="스크린샷 2026-02-04 오전 2 07 43" src="https://github.com/user-attachments/assets/5a2187a8-3e15-4055-88a0-70a9157355dc" />

토큰 유효기간을 짧게 설정하고 토큰 갱신이 되는지도 확인했습니다!