### PR TITLE
사용자 닉네임 처리 개선 및 upsert 최적화

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,7 +13,7 @@
     "dev": "nest start --watch",
     "prestart:debug": "npm run prisma:deploy && npm run prisma:generate",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/apps/backend/src/oidc/guards/oidc.guard.ts
+++ b/apps/backend/src/oidc/guards/oidc.guard.ts
@@ -30,9 +30,9 @@ export class OidcGuard implements CanActivate {
       // 토큰 검증 및 페이로드 추출 (issuer 기반 동적 검증)
       const payload = await this.oidcService.validateTokenWithIssuer(token);
 
-      const preferred_username = payload.preferred_username;
-      if (!preferred_username) {
-        throw new UnauthorizedException("OIDC 토큰에 preferred_username이 필요합니다.");
+      const nickname = payload.nickname;
+      if (!nickname) {
+        throw new UnauthorizedException("OIDC 토큰에 nickname이 필요합니다.");
       }
 
       const uuid = payload.sub;
@@ -44,8 +44,7 @@ export class OidcGuard implements CanActivate {
       if (!payload.email) {
         throw new UnauthorizedException("OIDC 토큰에 email이 필요합니다.");
       }
-
-      const user = await this.userService.findOrCreate(uuid, preferred_username, payload.email);
+      const user = await this.userService.findOrCreate(uuid, nickname, payload.email);
 
       /**
        * 요청 객체에 사용자 정보 추가

--- a/apps/backend/src/user/user.repository.ts
+++ b/apps/backend/src/user/user.repository.ts
@@ -40,14 +40,15 @@ export class UserRepository {
     });
 
     if (existingUser) {
-      const updated = await this.prisma.user.update({
-        where: { uuid: data.uuid },
-        data: {
-          email: data.email,
-          nickname: data.nickname,
-        },
-      });
-      return UserMapper.fromPrisma(updated);
+      // 변경된 경우에만 업데이트
+      if (existingUser.email !== data.email || existingUser.nickname !== data.nickname) {
+        const updated = await this.prisma.user.update({
+          where: { uuid: data.uuid },
+          data: { email: data.email, nickname: data.nickname },
+        });
+        return UserMapper.fromPrisma(updated);
+      }
+      return UserMapper.fromPrisma(existingUser);
     }
 
     const created = await this.prisma.user.create({

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -6,7 +6,7 @@ import { User } from "./entities/user.entity";
 export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
-    /**
+  /**
    * 사용자 조회 또는 생성 (OIDC 로그인 시 사용)
    * @param userUuid 사용자 UUID
    * @param userNickname 사용자 닉네임

--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -75,7 +75,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
           setUser({
             uuid: userInfo.sub,
             email: userInfo.email || "",
-            nickname: userInfo.name || userInfo.preferred_username || "",
+            nickname: userInfo.nickname || userInfo.preferred_username || "",
           });
         } catch {
           // userinfo 조회 실패 - 토큰 삭제 후 재로그인 필요

--- a/apps/frontend/src/pages/AuthCallback.tsx
+++ b/apps/frontend/src/pages/AuthCallback.tsx
@@ -50,7 +50,7 @@ const AuthCallback = () => {
         setOAuthUser({
           sub: userInfo.sub,
           email: userInfo.email || "",
-          nickname: userInfo.name || userInfo.preferred_username || "",
+          nickname: userInfo.nickname || userInfo.preferred_username || "",
         });
 
         // 로그인 성공 후 세션스토리지에 저장된 리다이렉트 url있으면 그쪽으로, 아니면 팀 목록 페이지로 이동

--- a/apps/frontend/src/services/authentikAuth.ts
+++ b/apps/frontend/src/services/authentikAuth.ts
@@ -25,6 +25,7 @@ export interface AccessTokenPayload {
   name?: string;
   email?: string;
   preferred_username?: string;
+  nickname?: string;
   team_id?: string;
   exp: number;
   iat: number;


### PR DESCRIPTION
Closes #234 
Closes #245 

## 개요
- oidc 토큰에서 `preferred_username` 대신 `nickname` 클레임을 사용하도록 변경
- 로그인 시 사용자 정보가 변경된 경우에만 db 업데이트 하도록 최적화

## 주요 변경사항
- `oidc.guard`: 토큰 닉네임 추출 시 `preferred_name` 을 사용하고 있었음🥶 -> Nickname으로 변경
- `user.repository`: upsert시 email/nickname이 동일하면 update 쿼리 스킵

⬇️ 변경되기 전 `con_사용예시`
<img width="913" height="393" alt="스크린샷 2026-02-04 오전 11 16 16" src="https://github.com/user-attachments/assets/fbfe0907-fe4a-4928-847b-a6567e8053f7" />
⬇️ 로그인 후 authentik에서 보내주는 대로 `con_사용자명` 으로 변경 됨
<img width="938" height="375" alt="스크린샷 2026-02-04 오전 11 16 40" src="https://github.com/user-attachments/assets/fe7c3a9a-e45e-4612-9996-162b81a6475c" />
