### PR TITLE
Refactor/244 Sidebar 컴포넌트 분리

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -117,7 +117,10 @@ const Sidebar = ({
     <aside className="w-64 bg-white border-r border-gray-200 flex flex-col h-full">
       {/* 로고 */}
       <div className="h-14 px-4 border-b border-gray-200 flex items-center">
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2 cursor-pointer"
+          onClick={() => navigate("/my-teams")}
+        >
           <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
             <span className="text-white font-bold text-sm">TS</span>
           </div>

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -1,16 +1,10 @@
 import { useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
-import {
-  Users,
-  ChevronRight,
-  Folder,
-  FolderPlus,
-  Trash2,
-  Settings,
-} from "lucide-react";
+import { Users } from "lucide-react";
 import type { Team, Folder as FolderType } from "../../types";
 import { useTeams } from "../../contexts/TeamContext";
 import { useFolders } from "../../hooks";
+import TeamItem from "./sidebar/TeamItem";
 
 interface SidebarProps {
   onCreateTeam?: () => void;
@@ -22,7 +16,7 @@ interface SidebarProps {
   ) => void;
   selectedFolderUuid?: string | null;
   onFolderSelect?: (folder: FolderType) => void;
-  folderRefreshKey?: number; // 이 값이 변경되면 선택된 팀의 폴더 캐시를 무효화하고 다시 조회
+  folderRefreshKey?: number;
 }
 
 const Sidebar = ({
@@ -51,20 +45,12 @@ const Sidebar = ({
   const [manualExpandedTeams, setManualExpandedTeams] = useState<
     Record<string, boolean>
   >({});
-  // 호버 중인 팀
-  const [hoveredTeamUuid, setHoveredTeamUuid] = useState<string | null>(null);
-  // 호버 중인 폴더
-  const [hoveredFolderUuid, setHoveredFolderUuid] = useState<string | null>(
-    null,
-  );
 
   // 팀이 펼쳐져 있는지 계산 (수동 상태 우선, 없으면 선택된 팀만 펼침)
   const isTeamExpanded = (teamUuid: string): boolean => {
-    // 수동 상태가 있으면 그것을 따름 (선택된 팀도 접기 가능)
     if (manualExpandedTeams[teamUuid] !== undefined) {
       return manualExpandedTeams[teamUuid];
     }
-    // 선택된 팀은 기본적으로 펼침
     if (selectedTeamUuid === teamUuid) {
       return true;
     }
@@ -90,53 +76,40 @@ const Sidebar = ({
   };
 
   const handleFolderClick = (folder: FolderType, team: Team) => {
-    // 이미 선택된 폴더면 아무것도 하지 않음
-    if (selectedFolderUuid === folder.folderUuid) return;
+    if (selectedFolderUuid === folder.folderUuid && !isSettingPage) return;
 
-    // 현재 선택된 팀의 폴더면 콜백으로 처리 (페이지 이동 없이)
-    if (selectedTeamUuid === team.teamUuid) {
+    if (selectedTeamUuid === team.teamUuid && !isSettingPage) {
       onFolderSelect?.(folder);
     } else {
-      // 다른 팀의 폴더면 해당 팀 페이지로 이동 + 폴더 선택
       navigate(`/team/${team.teamUuid}`, {
         state: { team, selectedFolderUuid: folder.folderUuid },
       });
     }
   };
 
-  const handleSettingClick = (e: React.MouseEvent, teamUuid: string) => {
-    e.stopPropagation();
+  const handleSettingClick = (teamUuid: string) => {
     navigate(`/team/${teamUuid}/setting`);
   };
 
-  const handleCreateFolderClick = (e: React.MouseEvent, teamUuid: string) => {
-    e.stopPropagation();
-
-    // 선택된 팀이 아닌 경우 alert 표시
+  const handleCreateFolderClick = (teamUuid: string) => {
     if (teamUuid !== selectedTeamUuid) {
       const targetTeam = teams.find((t) => t.teamUuid === teamUuid);
       const teamName = targetTeam?.teamName || "해당";
       alert(`${teamName} 팀 페이지에서 폴더를 생성할 수 있습니다.`);
       return;
     }
-
     onCreateFolder?.(teamUuid);
   };
 
   const handleDeleteFolderClick = (
-    e: React.MouseEvent,
     team: Team,
     folderUuid: string,
     folderName: string,
   ) => {
-    e.stopPropagation();
-
-    // 선택된 팀이 아닌 경우 alert 표시
     if (team.teamUuid !== selectedTeamUuid) {
       alert(`${team.teamName} 팀 페이지에서 폴더를 삭제할 수 있습니다.`);
       return;
     }
-
     onDeleteFolder?.(team.teamUuid, folderUuid, folderName);
   };
 
@@ -174,157 +147,25 @@ const Sidebar = ({
           </div>
         ) : teams.length > 0 ? (
           <div className="mt-2 space-y-1">
-            {teams.map((team) => {
-              const isExpanded = isTeamExpanded(team.teamUuid);
-              const isSelected = selectedTeamUuid === team.teamUuid;
-              const isHovered = hoveredTeamUuid === team.teamUuid;
-              const folders = teamFolders[team.teamUuid] || [];
-
-              return (
-                <div key={team.teamUuid} className="ml-2">
-                  {/* 팀 헤더 */}
-                  <div
-                    className={`group flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors cursor-pointer ${
-                      isSelected && !isSettingPage
-                        ? "bg-blue-50 text-blue-600"
-                        : "text-gray-700 hover:bg-gray-100"
-                    }`}
-                    onMouseEnter={() => setHoveredTeamUuid(team.teamUuid)}
-                    onMouseLeave={() => setHoveredTeamUuid(null)}
-                    onClick={() => handleTeamClick(team)}
-                  >
-                    {/* 펼침/접힘 버튼 */}
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleTeamExpand(team.teamUuid);
-                      }}
-                      className="p-0.5 hover:bg-gray-200 rounded cursor-pointer transition-transform duration-200"
-                    >
-                      <ChevronRight
-                        className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
-                      />
-                    </button>
-
-                    {/* 팀 아이콘 */}
-                    <Users className="w-4 h-4 shrink-0" />
-
-                    {/* 팀 이름 */}
-                    <span className="text-sm font-medium flex-1 truncate">
-                      {team.teamName}
-                    </span>
-
-                    {/* 호버 시 액션 버튼들 - opacity로 표시/숨김 */}
-                    <div
-                      className={`flex items-center gap-0.5 transition-opacity duration-150 ${
-                        isHovered ? "opacity-100" : "opacity-0"
-                      }`}
-                    >
-                      <button
-                        onClick={(e) =>
-                          handleCreateFolderClick(e, team.teamUuid)
-                        }
-                        className="p-1 hover:bg-gray-200 rounded cursor-pointer"
-                        title="폴더 생성"
-                      >
-                        <FolderPlus className="w-4 h-4 text-gray-500" />
-                      </button>
-                      <button
-                        onClick={(e) => handleSettingClick(e, team.teamUuid)}
-                        className="p-1 hover:bg-gray-200 rounded cursor-pointer"
-                        title="팀 설정"
-                      >
-                        <Settings className="w-4 h-4 text-gray-500" />
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* 폴더 목록 - 애니메이션 적용 */}
-                  {(() => {
-                    // 선택된 폴더가 현재 폴더 목록에 있는지 확인
-                    const selectedFolderInList =
-                      selectedFolderUuid &&
-                      folders.some((f) => f.folderUuid === selectedFolderUuid);
-
-                    return (
-                      <div
-                        className={`ml-6 space-y-0.5 transition-all duration-200 ease-in-out custom-scrollbar ${
-                          isExpanded && folders.length > 0
-                            ? "max-h-64 opacity-100 mt-1 overflow-y-auto"
-                            : "max-h-0 opacity-0 overflow-hidden"
-                        }`}
-                      >
-                        {folders.map((folder, index) => {
-                          // 선택된 폴더가 없거나 폴더 목록에 없으면 첫번째 폴더(기본 폴더)를 자동 선택
-                          const isFolderSelected =
-                            isSelected &&
-                            !isSettingPage &&
-                            (selectedFolderUuid === folder.folderUuid ||
-                              (!selectedFolderInList && index === 0));
-
-                          const isFolderHovered =
-                            hoveredFolderUuid === folder.folderUuid;
-                          const isDefaultFolder = index === 0; // 첫번째 폴더는 기본 폴더
-
-                          return (
-                            <div
-                              key={folder.folderUuid}
-                              role="button"
-                              tabIndex={0}
-                              className={`group flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors cursor-pointer ${
-                                isFolderSelected
-                                  ? "bg-blue-100 text-blue-700"
-                                  : "text-gray-600 hover:bg-gray-100"
-                              }`}
-                              onMouseEnter={() =>
-                                setHoveredFolderUuid(folder.folderUuid)
-                              }
-                              onMouseLeave={() => setHoveredFolderUuid(null)}
-                              onClick={() => handleFolderClick(folder, team)}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                  e.preventDefault();
-                                  handleFolderClick(folder, team);
-                                }
-                              }}
-                            >
-                              <Folder className="w-4 h-4 shrink-0" />
-                              <span
-                                className={`text-sm flex-1 truncate ${isFolderSelected ? "font-medium" : ""}`}
-                              >
-                                {folder.folderName}
-                              </span>
-
-                              {/* 호버 시 삭제 버튼 (기본 폴더 제외) */}
-                              {!isDefaultFolder && (
-                                <button
-                                  onClick={(e) =>
-                                    handleDeleteFolderClick(
-                                      e,
-                                      team,
-                                      folder.folderUuid,
-                                      folder.folderName,
-                                    )
-                                  }
-                                  className={`p-1 hover:bg-gray-200 rounded cursor-pointer transition-opacity duration-150 ${
-                                    isFolderHovered
-                                      ? "opacity-100"
-                                      : "opacity-0"
-                                  }`}
-                                  title="폴더 삭제"
-                                >
-                                  <Trash2 className="w-3.5 h-3.5 text-gray-500" />
-                                </button>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    );
-                  })()}
-                </div>
-              );
-            })}
+            {teams.map((team) => (
+              <TeamItem
+                key={team.teamUuid}
+                team={team}
+                isSelected={selectedTeamUuid === team.teamUuid}
+                isSettingPage={isSettingPage}
+                isExpanded={isTeamExpanded(team.teamUuid)}
+                folders={teamFolders[team.teamUuid] || []}
+                selectedFolderUuid={selectedFolderUuid}
+                onTeamClick={() => handleTeamClick(team)}
+                onToggleExpand={() => toggleTeamExpand(team.teamUuid)}
+                onFolderClick={(folder) => handleFolderClick(folder, team)}
+                onCreateFolder={() => handleCreateFolderClick(team.teamUuid)}
+                onDeleteFolder={(folderUuid, folderName) =>
+                  handleDeleteFolderClick(team, folderUuid, folderName)
+                }
+                onSettingClick={() => handleSettingClick(team.teamUuid)}
+              />
+            ))}
           </div>
         ) : (
           <p className="mt-2 ml-6 text-xs text-gray-400">

--- a/apps/frontend/src/components/layout/sidebar/FolderItem.tsx
+++ b/apps/frontend/src/components/layout/sidebar/FolderItem.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { Folder, Trash2 } from "lucide-react";
+import type { Folder as FolderType } from "../../../types";
+
+interface FolderItemProps {
+  folder: FolderType;
+  isSelected: boolean;
+  isDefaultFolder: boolean;
+  onClick: () => void;
+  onDelete: () => void;
+}
+
+const FolderItem = ({
+  folder,
+  isSelected,
+  isDefaultFolder,
+  onClick,
+  onDelete,
+}: FolderItemProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete();
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={`group flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors cursor-pointer ${
+        isSelected
+          ? "bg-blue-100 text-blue-700"
+          : "text-gray-600 hover:bg-gray-100"
+      }`}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+    >
+      <Folder className="w-4 h-4 shrink-0" />
+      <span
+        className={`text-sm flex-1 truncate ${isSelected ? "font-medium" : ""}`}
+      >
+        {folder.folderName}
+      </span>
+
+      {/* 호버 시 삭제 버튼 (기본 폴더 제외) */}
+      {!isDefaultFolder && (
+        <button
+          onClick={handleDeleteClick}
+          className={`p-1 hover:bg-gray-200 rounded cursor-pointer transition-opacity duration-150 ${
+            isHovered ? "opacity-100" : "opacity-0"
+          }`}
+          title="폴더 삭제"
+        >
+          <Trash2 className="w-3.5 h-3.5 text-gray-500" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default FolderItem;

--- a/apps/frontend/src/components/layout/sidebar/FolderItem.tsx
+++ b/apps/frontend/src/components/layout/sidebar/FolderItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Folder, Trash2 } from "lucide-react";
 import type { Folder as FolderType } from "../../../types";
 
@@ -18,6 +18,14 @@ const FolderItem = ({
   onDelete,
 }: FolderItemProps) => {
   const [isHovered, setIsHovered] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const nameRef = useRef<HTMLSpanElement>(null);
+
+  const handleNameMouseEnter = () => {
+    if (nameRef.current) {
+      setShowTooltip(nameRef.current.scrollWidth > nameRef.current.clientWidth);
+    }
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {
@@ -47,7 +55,10 @@ const FolderItem = ({
     >
       <Folder className="w-4 h-4 shrink-0" />
       <span
+        ref={nameRef}
         className={`text-sm flex-1 truncate ${isSelected ? "font-medium" : ""}`}
+        title={showTooltip ? folder.folderName : undefined}
+        onMouseEnter={handleNameMouseEnter}
       >
         {folder.folderName}
       </span>

--- a/apps/frontend/src/components/layout/sidebar/TeamItem.tsx
+++ b/apps/frontend/src/components/layout/sidebar/TeamItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Users, ChevronRight, FolderPlus, Settings } from "lucide-react";
 import type { Team, Folder as FolderType } from "../../../types";
 import FolderItem from "./FolderItem";
@@ -33,6 +33,14 @@ const TeamItem = ({
   onSettingClick,
 }: TeamItemProps) => {
   const [isHovered, setIsHovered] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const nameRef = useRef<HTMLSpanElement>(null);
+
+  const handleNameMouseEnter = () => {
+    if (nameRef.current) {
+      setShowTooltip(nameRef.current.scrollWidth > nameRef.current.clientWidth);
+    }
+  };
 
   // 선택된 폴더가 현재 폴더 목록에 있는지 확인
   const selectedFolderInList =
@@ -81,7 +89,12 @@ const TeamItem = ({
         <Users className="w-4 h-4 shrink-0" />
 
         {/* 팀 이름 */}
-        <span className="text-sm font-medium flex-1 truncate">
+        <span
+          ref={nameRef}
+          className="text-sm font-medium flex-1 truncate"
+          title={showTooltip ? team.teamName : undefined}
+          onMouseEnter={handleNameMouseEnter}
+        >
           {team.teamName}
         </span>
 

--- a/apps/frontend/src/components/layout/sidebar/TeamItem.tsx
+++ b/apps/frontend/src/components/layout/sidebar/TeamItem.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Users, ChevronRight, FolderPlus, Settings } from "lucide-react";
+import type { Team, Folder as FolderType } from "../../../types";
+import FolderItem from "./FolderItem";
+
+interface TeamItemProps {
+  team: Team;
+  isSelected: boolean;
+  isSettingPage: boolean;
+  isExpanded: boolean;
+  folders: FolderType[];
+  selectedFolderUuid?: string | null;
+  onTeamClick: () => void;
+  onToggleExpand: () => void;
+  onFolderClick: (folder: FolderType) => void;
+  onCreateFolder: () => void;
+  onDeleteFolder: (folderUuid: string, folderName: string) => void;
+  onSettingClick: () => void;
+}
+
+const TeamItem = ({
+  team,
+  isSelected,
+  isSettingPage,
+  isExpanded,
+  folders,
+  selectedFolderUuid,
+  onTeamClick,
+  onToggleExpand,
+  onFolderClick,
+  onCreateFolder,
+  onDeleteFolder,
+  onSettingClick,
+}: TeamItemProps) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  // 선택된 폴더가 현재 폴더 목록에 있는지 확인
+  const selectedFolderInList =
+    selectedFolderUuid &&
+    folders.some((f) => f.folderUuid === selectedFolderUuid);
+
+  const handleExpandClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleExpand();
+  };
+
+  const handleCreateFolderClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onCreateFolder();
+  };
+
+  const handleSettingClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onSettingClick();
+  };
+
+  return (
+    <div className="ml-2">
+      {/* 팀 헤더 */}
+      <div
+        className={`group flex items-center gap-1 px-2 py-1.5 rounded-lg transition-colors cursor-pointer ${
+          isSelected && !isSettingPage
+            ? "bg-blue-50 text-blue-600"
+            : "text-gray-700 hover:bg-gray-100"
+        }`}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onClick={onTeamClick}
+      >
+        {/* 펼침/접힘 버튼 */}
+        <button
+          onClick={handleExpandClick}
+          className="p-0.5 hover:bg-gray-200 rounded cursor-pointer transition-transform duration-200"
+        >
+          <ChevronRight
+            className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
+          />
+        </button>
+
+        {/* 팀 아이콘 */}
+        <Users className="w-4 h-4 shrink-0" />
+
+        {/* 팀 이름 */}
+        <span className="text-sm font-medium flex-1 truncate">
+          {team.teamName}
+        </span>
+
+        {/* 호버 시 액션 버튼들 */}
+        <div
+          className={`flex items-center gap-0.5 transition-opacity duration-150 ${
+            isHovered ? "opacity-100" : "opacity-0"
+          }`}
+        >
+          <button
+            onClick={handleCreateFolderClick}
+            className="p-1 hover:bg-gray-200 rounded cursor-pointer"
+            title="폴더 생성"
+          >
+            <FolderPlus className="w-4 h-4 text-gray-500" />
+          </button>
+          <button
+            onClick={handleSettingClick}
+            className="p-1 hover:bg-gray-200 rounded cursor-pointer"
+            title="팀 설정"
+          >
+            <Settings className="w-4 h-4 text-gray-500" />
+          </button>
+        </div>
+      </div>
+
+      {/* 폴더 목록 */}
+      <div
+        className={`ml-6 space-y-0.5 transition-all duration-200 ease-in-out custom-scrollbar ${
+          isExpanded && folders.length > 0
+            ? "max-h-64 opacity-100 mt-1 overflow-y-auto"
+            : "max-h-0 opacity-0 overflow-hidden"
+        }`}
+      >
+        {folders.map((folder, index) => {
+          // 선택된 폴더가 없거나 폴더 목록에 없으면 첫번째 폴더(기본 폴더)를 자동 선택
+          const isFolderSelected =
+            isSelected &&
+            !isSettingPage &&
+            (selectedFolderUuid === folder.folderUuid ||
+              (!selectedFolderInList && index === 0));
+
+          const isDefaultFolder = index === 0;
+
+          return (
+            <FolderItem
+              key={folder.folderUuid}
+              folder={folder}
+              isSelected={isFolderSelected}
+              isDefaultFolder={isDefaultFolder}
+              onClick={() => onFolderClick(folder)}
+              onDelete={() =>
+                onDeleteFolder(folder.folderUuid, folder.folderName)
+              }
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TeamItem;


### PR DESCRIPTION
Sidebar 컴포넌트를 TeamItem, FolderItem으로 분리하고 설정 페이지에서 폴더 클릭 시 해당 팀 페이지의 폴더로 이동하도록 개선했습니다.

Closes #244 
Closes #228 
Closes #235 

## 작업 내용

### 컴포넌트 분리

**FolderItem.tsx**
- 폴더 1개를 렌더링하는 컴포넌트
- 폴더 아이콘 + 이름 표시
- 호버 시 삭제 버튼 표시 (기본 폴더 제외)

**TeamItem.tsx**
- 팀 1개를 렌더링하는 컴포넌트
- 팀 헤더: 펼침/접힘 버튼, 팀 아이콘, 팀 이름
- 호버 시 액션 버튼 표시: 폴더 생성, 팀 설정
- 폴더 목록을 FolderItem으로 렌더링

**Sidebar.tsx**
- 전체 사이드바 레이아웃
- 데이터 관리
- 라우팅 처리
- 폴더 생성/삭제 권한 체크
- 팀 목록을 TeamItem으로 렌더링

### 기능 개선
설정 페이지에서 폴더 클릭 시 해당 팀 페이지의 폴더로 이동하도록 변경

로고 클릭 시 메인화면으로 이동하는 이동하는 기능도 추가했습니다!
사이드바에서 팀/폴더 이름이 잘렸을 때만 튤팁 표시하는 기능도 추가했습니다!