### PR TITLE
[REFACTOR] SettingPage 파일 분리 및 ux 개선

### DIFF
--- a/apps/frontend/src/components/setting/MemberSection.tsx
+++ b/apps/frontend/src/components/setting/MemberSection.tsx
@@ -84,7 +84,7 @@ export const MemberSection = ({
         }
       >
         {/* 멤버 목록 렌더링 */}
-        <div className="space-y-1">
+        <div className="space-y-1 max-h-[320px] overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent">
           {sortedMembers.map((member) => (
             <div
               key={member.userUuid}

--- a/apps/frontend/src/components/setting/MemberSection.tsx
+++ b/apps/frontend/src/components/setting/MemberSection.tsx
@@ -1,0 +1,133 @@
+import { useState, useMemo } from "react";
+import { Users, Copy, Check, Crown } from "lucide-react";
+import type { GetTeamMembersResponseData } from "@repo/api";
+import SectionContainer from "../common/SectionContainer";
+import { TransferOwnershipModal } from "./TransferOwnershipModal";
+
+interface MemberSectionProps {
+  members: GetTeamMembersResponseData[];
+  currentUserUuid: string | undefined;
+  teamUuid: string;
+  isAdmin: boolean;
+  onTransferSuccess: () => void;
+  onError?: (message: string) => void;
+}
+
+export const MemberSection = ({
+  members,
+  currentUserUuid,
+  teamUuid,
+  isAdmin,
+  onTransferSuccess,
+  onError,
+}: MemberSectionProps) => {
+  const [copied, setCopied] = useState(false);
+  const [transferModalOpen, setTransferModalOpen] = useState(false);
+
+  const sortedMembers = useMemo(() => {
+    return [...members].sort((a, b) => {
+      if (a.userUuid === currentUserUuid) return -1;
+      if (b.userUuid === currentUserUuid) return 1;
+      if (a.role === "owner") return -1;
+      if (b.role === "owner") return 1;
+      return 0;
+    });
+  }, [members, currentUserUuid]);
+
+  const handleCopyInviteLink = async () => {
+    const inviteLink = `${window.location.origin}/team/${teamUuid}/invite`;
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      onError?.("링크 복사에 실패했습니다.");
+    }
+  };
+
+  return (
+    <>
+      <SectionContainer
+        title={`팀원 (${members.length}명)`}
+        headerAction={
+          <div className="flex gap-2">
+            {isAdmin && members.length > 1 && (
+              <button
+                onClick={() => setTransferModalOpen(true)}
+                className="flex items-center gap-2 px-3 py-1.5 text-sm text-amber-600 border border-amber-200 rounded-lg hover:bg-amber-50 transition-colors cursor-pointer"
+              >
+                <Crown className="w-4 h-4" />
+                권한 위임
+              </button>
+            )}
+            <button
+              onClick={handleCopyInviteLink}
+              className={`flex items-center justify-center gap-2 px-3 py-1.5 text-sm min-w-[120px] rounded-lg transition-colors cursor-pointer ${
+                copied
+                  ? "text-blue-600 border border-blue-300 bg-blue-50"
+                  : "text-blue-600 border border-blue-200 hover:bg-blue-50"
+              }`}
+            >
+              {copied ? (
+                <>
+                  <Check className="w-4 h-4" />
+                  <span>복사됨!</span>
+                </>
+              ) : (
+                <>
+                  <Copy className="w-4 h-4" />
+                  <span>초대 링크 복사</span>
+                </>
+              )}
+            </button>
+          </div>
+        }
+      >
+        {/* 멤버 목록 렌더링 */}
+        <div className="space-y-1">
+          {sortedMembers.map((member) => (
+            <div
+              key={member.userUuid}
+              className="flex items-center justify-between py-3"
+            >
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
+                  <Users className="w-5 h-5 text-gray-500" />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-gray-900">
+                      {member.userName}
+                    </span>
+                    {member.role === "owner" && (
+                      <span className="flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-600 rounded-full text-xs font-medium">
+                        <Crown className="w-3 h-3" />
+                        owner
+                      </span>
+                    )}
+                    {member.userUuid === currentUserUuid && (
+                      <span className="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs font-medium">
+                        me
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-sm text-gray-500">
+                    {member.userEmail}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </SectionContainer>
+
+      <TransferOwnershipModal
+        isOpen={transferModalOpen}
+        onClose={() => setTransferModalOpen(false)}
+        members={sortedMembers.filter((m) => m.role !== "owner")}
+        teamUuid={teamUuid}
+        onSuccess={onTransferSuccess}
+      />
+    </>
+  );
+};

--- a/apps/frontend/src/components/setting/TeamInfoSection.tsx
+++ b/apps/frontend/src/components/setting/TeamInfoSection.tsx
@@ -1,0 +1,33 @@
+import SectionContainer from "../common/SectionContainer";
+import type { Team } from "../../types";
+
+interface TeamInfoSectionProps {
+  team: Team | null;
+}
+
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+export const TeamInfoSection = ({ team }: TeamInfoSectionProps) => {
+  return (
+    <SectionContainer title="팀 정보">
+      <div className="space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">팀 이름</span>
+          <span className="font-medium text-gray-900">{team?.teamName}</span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">생성일</span>
+          <span className="text-gray-900">
+            {team?.createdAt && formatDate(team.createdAt)}
+          </span>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+};

--- a/apps/frontend/src/components/setting/TeamLeaveSection.tsx
+++ b/apps/frontend/src/components/setting/TeamLeaveSection.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { LogOut, Trash2 } from "lucide-react";
+import { teamApi } from "../../services/api";
+import SectionContainer from "../common/SectionContainer";
+import { DeleteTeamModal } from "./DeleteTeamModal";
+
+interface TeamLeaveSectionProps {
+  teamUuid: string;
+  teamName: string;
+  isAdmin: boolean;
+  isAlone: boolean;
+  onDeleteSuccess: () => void;
+  onError?: (message: string) => void;
+}
+
+export const TeamLeaveSection = ({
+  teamUuid,
+  teamName,
+  isAdmin,
+  isAlone,
+  onDeleteSuccess,
+  onError,
+}: TeamLeaveSectionProps) => {
+  const navigate = useNavigate();
+  const [leaving, setLeaving] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
+  const handleLeaveTeam = async () => {
+    if (!confirm("정말 이 팀에서 탈퇴하시겠습니까?")) return;
+
+    try {
+      setLeaving(true);
+      await teamApi.leaveTeam(teamUuid!);
+      navigate("/my-teams");
+    } catch {
+      onError?.("팀 탈퇴에 실패했습니다.");
+    } finally {
+      setLeaving(false);
+    }
+  };
+
+  return (
+    <>
+      <SectionContainer
+        title={isAdmin && isAlone ? "팀 삭제" : "팀 탈퇴"}
+        subtitle={
+          isAdmin && isAlone
+            ? "팀을 삭제하면 모든 데이터가 영구적으로 삭제됩니다."
+            : isAdmin
+              ? "관리자는 팀에서 탈퇴할 수 없습니다. 다른 멤버에게 관리자 권한을 넘긴 후 탈퇴해주세요."
+              : "팀에서 탈퇴하면 더 이상 이 팀의 콘텐츠에 접근할 수 없습니다."
+        }
+      >
+        {isAdmin && isAlone ? (
+          <button
+            onClick={() => setDeleteModalOpen(true)}
+            className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"
+          >
+            <Trash2 className="w-4 h-4" />팀 삭제
+          </button>
+        ) : (
+          <button
+            onClick={handleLeaveTeam}
+            disabled={isAdmin || leaving}
+            className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <LogOut className="w-4 h-4" />
+            {leaving ? "탈퇴 중..." : "팀 탈퇴"}
+          </button>
+        )}
+      </SectionContainer>
+
+      <DeleteTeamModal
+        isOpen={deleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        teamName={teamName}
+        teamUuid={teamUuid}
+        onSuccess={onDeleteSuccess}
+      />
+    </>
+  );
+};

--- a/apps/frontend/src/components/setting/TokenUsageSection.tsx
+++ b/apps/frontend/src/components/setting/TokenUsageSection.tsx
@@ -1,0 +1,38 @@
+import SectionContainer from "../common/SectionContainer";
+
+interface TokenUsageSectionProps {
+  tokenUsage: {
+    usedTokens: number;
+    maxTokens: number;
+    percentage: number;
+  } | null;
+}
+
+export const TokenUsageSection = ({ tokenUsage }: TokenUsageSectionProps) => {
+  if (!tokenUsage) return null;
+
+  return (
+    <SectionContainer title="AI 사용량">
+      <div className="space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">오늘 사용량</span>
+        </div>
+        {/* 프로그레스 바 */}
+        <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-blue-600 rounded-full transition-all"
+            style={{ width: `${tokenUsage.percentage}%` }}
+          />
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-gray-500">
+            매일 자정(KST)에 초기화됩니다
+          </span>
+          <span className="text-sm font-medium text-blue-600">
+            {tokenUsage.percentage}% 사용
+          </span>
+        </div>
+      </div>
+    </SectionContainer>
+  );
+};

--- a/apps/frontend/src/components/setting/WebhookSection.tsx
+++ b/apps/frontend/src/components/setting/WebhookSection.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import type { GetTeamWebhooksResponseData } from "@repo/api";
+import { teamApi } from "../../services/api";
+import SectionContainer from "../common/SectionContainer";
+
+interface WebhookSectionProps {
+  teamUuid: string;
+  webhooks: GetTeamWebhooksResponseData[];
+  setWebhooks: React.Dispatch<
+    React.SetStateAction<GetTeamWebhooksResponseData[]>
+  >;
+  isAdmin: boolean;
+  onError?: (message: string) => void;
+}
+
+export const WebhookSection = ({
+  teamUuid,
+  webhooks,
+  setWebhooks,
+  isAdmin,
+  onError,
+}: WebhookSectionProps) => {
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [isAddingWebhook, setIsAddingWebhook] = useState(false);
+  const [showWebhookInput, setShowWebhookInput] = useState(false);
+
+  const handleAddWebhook = async () => {
+    if (!webhookUrl.trim() || !teamUuid) return;
+
+    try {
+      setIsAddingWebhook(true);
+      const response = await teamApi.addTeamWebhooks(
+        teamUuid,
+        webhookUrl.trim(),
+      );
+      if (response.success) {
+        setWebhooks((prev) => [...prev, response.data]);
+        setWebhookUrl("");
+        setShowWebhookInput(false);
+      }
+    } catch {
+      onError?.("웹훅 추가에 실패했습니다.");
+    } finally {
+      setIsAddingWebhook(false);
+    }
+  };
+
+  const handleDeleteWebhook = async (webhookUuid: string) => {
+    if (!teamUuid) return;
+
+    try {
+      await teamApi.deleteTeamWebhooks(teamUuid, webhookUuid);
+      setWebhooks((prev) => prev.filter((w) => w.webhookUuid !== webhookUuid));
+    } catch {
+      onError?.("웹훅 삭제에 실패했습니다.");
+    }
+  };
+
+  const handleToggleWebhook = async (webhook: GetTeamWebhooksResponseData) => {
+    if (!teamUuid) return;
+
+    try {
+      const response = webhook.isActive
+        ? await teamApi.deactivateTeamWebhooks(teamUuid, webhook.webhookUuid)
+        : await teamApi.activateTeamWebhooks(teamUuid, webhook.webhookUuid);
+
+      if (response.success) {
+        setWebhooks((prev) =>
+          prev.map((w) =>
+            w.webhookUuid === webhook.webhookUuid ? response.data : w,
+          ),
+        );
+      }
+    } catch {
+      onError?.("웹훅 상태 변경에 실패했습니다.");
+    }
+  };
+
+  return (
+    <SectionContainer
+      title="웹훅 관리"
+      badge={isAdmin ? "Owner" : undefined}
+      subtitle="팀 내 이벤트 발생 시 데이터를 전송할 URL을 관리합니다."
+    >
+      {/* 웹훅 목록 */}
+      <div className="space-y-3 mb-4">
+        {webhooks.length === 0 ? (
+          <p className="text-sm text-gray-400 py-2">등록된 웹훅이 없습니다.</p>
+        ) : (
+          webhooks.map((webhook) => (
+            <div
+              key={webhook.webhookUuid}
+              className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg"
+            >
+              {/* 토글 스위치 - owner만 클릭 가능 */}
+              {isAdmin ? (
+                <button
+                  onClick={() => handleToggleWebhook(webhook)}
+                  className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                    webhook.isActive ? "bg-blue-600" : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                      webhook.isActive ? "translate-x-5" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              ) : (
+                <div
+                  className={`relative w-11 h-6 rounded-full ${
+                    webhook.isActive ? "bg-blue-600" : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full ${
+                      webhook.isActive ? "translate-x-5" : "translate-x-0"
+                    }`}
+                  />
+                </div>
+              )}
+
+              {/* URL */}
+              <span className="flex-1 text-sm text-gray-700 truncate">
+                {webhook.url}
+              </span>
+
+              {/* 삭제 버튼 - owner만 표시 */}
+              {isAdmin && (
+                <button
+                  onClick={() => handleDeleteWebhook(webhook.webhookUuid)}
+                  className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors cursor-pointer"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* 웹훅 추가 - owner만 표시 */}
+      {isAdmin &&
+        (showWebhookInput ? (
+          <div className="flex gap-2">
+            <input
+              type="url"
+              value={webhookUrl}
+              onChange={(e) => setWebhookUrl(e.target.value)}
+              placeholder="https://전송받을-주소를-입력하세요..."
+              className="flex-1 px-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              disabled={isAddingWebhook}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleAddWebhook();
+                }
+              }}
+            />
+            <button
+              onClick={handleAddWebhook}
+              disabled={!webhookUrl.trim() || isAddingWebhook}
+              className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isAddingWebhook ? "추가 중..." : "추가"}
+            </button>
+            <button
+              onClick={() => {
+                setShowWebhookInput(false);
+                setWebhookUrl("");
+              }}
+              className="px-3 py-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+            >
+              취소
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowWebhookInput(true)}
+            className="flex items-center gap-2 px-4 py-2 text-sm text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors cursor-pointer"
+          >
+            <Plus className="w-4 h-4" />
+            웹훅 추가
+          </button>
+        ))}
+    </SectionContainer>
+  );
+};

--- a/apps/frontend/src/components/setting/WebhookSection.tsx
+++ b/apps/frontend/src/components/setting/WebhookSection.tsx
@@ -39,8 +39,11 @@ export const WebhookSection = ({
         setWebhookUrl("");
         setShowWebhookInput(false);
       }
-    } catch {
-      onError?.("웹훅 추가에 실패했습니다.");
+    } catch (error) {
+      const message =
+        (error as { response?: { data?: { message?: string } } })?.response
+          ?.data?.message || "웹훅 추가에 실패했습니다.";
+      onError?.(message);
     } finally {
       setIsAddingWebhook(false);
     }

--- a/apps/frontend/src/pages/SettingPage.tsx
+++ b/apps/frontend/src/pages/SettingPage.tsx
@@ -4,16 +4,17 @@ import type {
   GetTeamMembersResponseData,
   GetTeamWebhooksResponseData,
 } from "@repo/api";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { useTeams } from "../contexts/TeamContext";
 import { teamApi } from "../services/api";
-import { Users, Copy, LogOut, Check, Crown, Plus, Trash2 } from "lucide-react";
 import Layout from "../components/layout/Layout";
 import CreateTeamModal from "../components/teams/CreateTeamModal";
-import SectionContainer from "../components/common/SectionContainer";
-import { TransferOwnershipModal } from "../components/setting/TransferOwnershipModal";
-import { DeleteTeamModal } from "../components/setting/DeleteTeamModal";
+import { TeamInfoSection } from "../components/setting/TeamInfoSection";
+import { MemberSection } from "../components/setting/MemberSection";
+import { TokenUsageSection } from "../components/setting/TokenUsageSection";
+import { WebhookSection } from "../components/setting/WebhookSection";
+import { TeamLeaveSection } from "../components/setting/TeamLeaveSection";
 
 const SettingPage = () => {
   const { teamUuid } = useParams<{ teamUuid: string }>();
@@ -23,47 +24,18 @@ const SettingPage = () => {
   const { addTeam, refreshTeams } = useTeams();
 
   const teamFromState = location.state?.team as Team | undefined;
-
   const [currentTeam, setCurrentTeam] = useState<Team | null>(null);
   const [members, setMembers] = useState<GetTeamMembersResponseData[]>([]);
-  // 혼자인지 확인
   const isAlone = members.length === 1;
   const [loading, setLoading] = useState(true);
-  const [, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const [leaving, setLeaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-
-  // 웹훅 관련 state 추가
   const [webhooks, setWebhooks] = useState<GetTeamWebhooksResponseData[]>([]);
-  const [webhookUrl, setWebhookUrl] = useState("");
-  const [isAddingWebhook, setIsAddingWebhook] = useState(false);
-  const [showWebhookInput, setShowWebhookInput] = useState(false);
-
-  // 토큰 관련 state
   const [tokenUsage, setTokenUsage] = useState<{
     usedTokens: number;
     maxTokens: number;
     percentage: number;
   } | null>(null);
-
-  const [transferModalOpen, setTransferModalOpen] = useState(false);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-
-  const sortedMembers = useMemo(() => {
-    return [...members].sort((a, b) => {
-      const aIsMe = a.userUuid === user?.uuid;
-      const bIsMe = b.userUuid === user?.uuid;
-
-      if (aIsMe) return -1;
-      if (bIsMe) return 1;
-
-      if (a.role === "owner") return -1;
-      if (b.role === "owner") return 1;
-
-      return 0;
-    });
-  }, [members, user?.uuid]);
 
   // 팀 정보 및 멤버 조회
   useEffect(() => {
@@ -139,106 +111,6 @@ const SettingPage = () => {
     fetchData();
   }, [teamUuid, teamFromState]);
 
-  // 초대 링크 복사
-  const handleCopyInviteLink = async () => {
-    const inviteLink = `${window.location.origin}/team/${teamUuid}/invite`;
-    try {
-      await navigator.clipboard.writeText(inviteLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      setError("링크 복사에 실패했습니다.");
-    }
-  };
-
-  // 팀 탈퇴
-  const handleLeaveTeam = async () => {
-    if (!confirm("정말 이 팀에서 탈퇴하시겠습니까?")) return;
-
-    try {
-      setLeaving(true);
-      await teamApi.leaveTeam(teamUuid!);
-      navigate("/my-teams");
-    } catch {
-      setError("팀 탈퇴에 실패했습니다.");
-    } finally {
-      setLeaving(false);
-    }
-  };
-
-  // 웹훅 추가
-  const handleAddWebhook = async () => {
-    if (!webhookUrl.trim() || !teamUuid) return;
-
-    try {
-      setIsAddingWebhook(true);
-      const response = await teamApi.addTeamWebhooks(
-        teamUuid,
-        webhookUrl.trim(),
-      );
-      if (response.success) {
-        setWebhooks((prev) => [...prev, response.data]);
-        setWebhookUrl("");
-        setShowWebhookInput(false);
-      }
-    } catch {
-      setError("웹훅 추가에 실패했습니다.");
-    } finally {
-      setIsAddingWebhook(false);
-    }
-  };
-
-  // 웹훅 삭제
-  const handleDeleteWebhook = async (webhookUuid: string) => {
-    if (!teamUuid) return;
-
-    try {
-      await teamApi.deleteTeamWebhooks(teamUuid, webhookUuid);
-      setWebhooks((prev) => prev.filter((w) => w.webhookUuid !== webhookUuid));
-    } catch {
-      setError("웹훅 삭제에 실패했습니다.");
-    }
-  };
-
-  // 웹훅 활성화/비활성화 토글
-  const handleToggleWebhook = async (webhook: GetTeamWebhooksResponseData) => {
-    if (!teamUuid) return;
-
-    try {
-      const response = webhook.isActive
-        ? await teamApi.deactivateTeamWebhooks(teamUuid, webhook.webhookUuid)
-        : await teamApi.activateTeamWebhooks(teamUuid, webhook.webhookUuid);
-
-      if (response.success) {
-        setWebhooks((prev) =>
-          prev.map((w) =>
-            w.webhookUuid === webhook.webhookUuid ? response.data : w,
-          ),
-        );
-      }
-    } catch {
-      setError("웹훅 상태 변경에 실패했습니다.");
-    }
-  };
-
-  // 날짜 포맷
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("ko-KR", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
-
-  const handleTransferSuccess = () => {
-    window.location.reload();
-  };
-
-  const handleDeleteSuccess = async () => {
-    await refreshTeams();
-    navigate("/my-teams");
-  };
-
   // 로딩 중
   if (loading) {
     return (
@@ -248,283 +120,56 @@ const SettingPage = () => {
     );
   }
 
+  const handleError = (message: string) => {
+    setError(message);
+    setTimeout(() => setError(null), 3000); // 3초 후 자동 사라짐
+  };
+
   const isAdmin = currentTeam?.role === "owner";
 
   return (
-    <Layout
-      sidebarProps={{
-        onCreateTeam: () => setIsModalOpen(true),
-      }}
-    >
-          <h1 className="text-2xl font-bold text-gray-900 mb-8">팀 설정</h1>
+    <Layout sidebarProps={{ onCreateTeam: () => setIsModalOpen(true) }}>
+      <h1 className="text-2xl font-bold text-gray-900 mb-8">팀 설정</h1>
 
-          <div className="max-w-4xl space-y-8">
-            {/* 팀 정보 섹션 */}
-            <SectionContainer title="팀 정보">
-              <div className="space-y-3">
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-600">팀 이름</span>
-                  <span className="font-medium text-gray-900">
-                    {currentTeam?.teamName}
-                  </span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-gray-600">생성일</span>
-                  <span className="text-gray-900">
-                    {currentTeam?.createdAt &&
-                      formatDate(currentTeam.createdAt)}
-                  </span>
-                </div>
-              </div>
-            </SectionContainer>
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm">
+          {error}
+        </div>
+      )}
 
-            {/* 멤버 목록 섹션 */}
-            <SectionContainer
-              title={`팀원 (${members.length}명)`}
-              headerAction={
-                <div className="flex gap-2">
-                  {isAdmin && members.length > 1 && (
-                    <button
-                      onClick={() => setTransferModalOpen(true)}
-                      className="flex items-center gap-2 px-3 py-1.5 text-sm text-amber-600 border border-amber-200 rounded-lg hover:bg-amber-50 transition-colors cursor-pointer"
-                    >
-                      <Crown className="w-4 h-4" />
-                      권한 위임
-                    </button>
-                  )}
-                  <button
-                    onClick={handleCopyInviteLink}
-                    className={`flex items-center justify-center gap-2 px-3 py-1.5 text-sm min-w-[120px] rounded-lg transition-colors cursor-pointer ${
-                      copied
-                        ? "text-blue-600 border border-blue-300 bg-blue-50"
-                        : "text-blue-600 border border-blue-200 hover:bg-blue-50"
-                    }`}
-                  >
-                    {copied ? (
-                      <>
-                        <Check className="w-4 h-4" />
-                        <span>복사됨!</span>
-                      </>
-                    ) : (
-                      <>
-                        <Copy className="w-4 h-4" />
-                        <span>초대 링크 복사</span>
-                      </>
-                    )}
-                  </button>
-                </div>
-              }
-            >
-              <div className="space-y-1">
-                {sortedMembers.map((member) => (
-                  <div
-                    key={member.userUuid}
-                    className="flex items-center justify-between py-3"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center">
-                        <Users className="w-5 h-5 text-gray-500" />
-                      </div>
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium text-gray-900">
-                            {member.userName}
-                          </span>
-                          {member.role === "owner" && (
-                            <span className="flex items-center gap-1 px-2 py-0.5 bg-amber-50 text-amber-600 rounded-full text-xs font-medium">
-                              <Crown className="w-3 h-3" />
-                              owner
-                            </span>
-                          )}
-                          {member.userUuid === user?.uuid && (
-                            <span className="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full text-xs font-medium">
-                              me
-                            </span>
-                          )}
-                        </div>
-                        <span className="text-sm text-gray-500">
-                          {member.userEmail}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
+      <div className="max-w-4xl space-y-8">
+        <TeamInfoSection team={currentTeam} />
 
-            </SectionContainer>
+        <MemberSection
+          members={members}
+          currentUserUuid={user?.uuid}
+          teamUuid={teamUuid!}
+          isAdmin={isAdmin}
+          onTransferSuccess={() => window.location.reload()}
+          onError={handleError}
+        />
 
-            {/* 토큰 사용량 섹션 */}
-            {tokenUsage && (
-              <SectionContainer title="AI 사용량">
-                <div className="space-y-3">
-                  <div className="flex justify-between items-center">
-                    <span className="text-gray-600">오늘 사용량</span>
-                  </div>
-                  {/* 프로그레스 바 */}
-                  <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-blue-600 rounded-full transition-all"
-                      style={{ width: `${tokenUsage.percentage}%` }}
-                    />
-                  </div>
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm text-gray-500">
-                      매일 자정(KST)에 초기화됩니다
-                    </span>
-                    <span className="text-sm font-medium text-blue-600">
-                      {tokenUsage.percentage}% 사용
-                    </span>
-                  </div>
-                </div>
-              </SectionContainer>
-            )}
+        <TokenUsageSection tokenUsage={tokenUsage} />
 
-            {/* 웹훅 관리 섹션 */}
-            <SectionContainer
-              title="웹훅 관리"
-              badge={isAdmin ? "Owner" : undefined}
-              subtitle="팀 내 이벤트 발생 시 데이터를 전송할 URL을 관리합니다."
-            >
-              {/* 웹훅 목록 */}
-              <div className="space-y-3 mb-4">
-                {webhooks.length === 0 ? (
-                  <p className="text-sm text-gray-400 py-2">
-                    등록된 웹훅이 없습니다.
-                  </p>
-                ) : (
-                  webhooks.map((webhook) => (
-                    <div
-                      key={webhook.webhookUuid}
-                      className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg"
-                    >
-                      {/* 토글 스위치 - owner만 클릭 가능 */}
-                      {isAdmin ? (
-                        <button
-                          onClick={() => handleToggleWebhook(webhook)}
-                          className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                            webhook.isActive ? "bg-blue-600" : "bg-gray-300"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
-                              webhook.isActive
-                                ? "translate-x-5"
-                                : "translate-x-0"
-                            }`}
-                          />
-                        </button>
-                      ) : (
-                        <div
-                          className={`relative w-11 h-6 rounded-full ${
-                            webhook.isActive ? "bg-blue-600" : "bg-gray-300"
-                          }`}
-                        >
-                          <span
-                            className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full ${
-                              webhook.isActive
-                                ? "translate-x-5"
-                                : "translate-x-0"
-                            }`}
-                          />
-                        </div>
-                      )}
+        <WebhookSection
+          teamUuid={teamUuid!}
+          webhooks={webhooks}
+          setWebhooks={setWebhooks}
+          isAdmin={isAdmin}
+          onError={handleError}
+        />
 
-                      {/* URL */}
-                      <span className="flex-1 text-sm text-gray-700 truncate">
-                        {webhook.url}
-                      </span>
-
-                      {/* 삭제 버튼 - owner만 표시 */}
-                      {isAdmin && (
-                        <button
-                          onClick={() =>
-                            handleDeleteWebhook(webhook.webhookUuid)
-                          }
-                          className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors cursor-pointer"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
-                  ))
-                )}
-              </div>
-
-              {/* 웹훅 추가 - owner만 표시 */}
-              {isAdmin &&
-                (showWebhookInput ? (
-                  <div className="flex gap-2">
-                    <input
-                      type="url"
-                      value={webhookUrl}
-                      onChange={(e) => setWebhookUrl(e.target.value)}
-                      placeholder="https://전송받을-주소를-입력하세요..."
-                      className="flex-1 px-4 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                      disabled={isAddingWebhook}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          handleAddWebhook();
-                        }
-                      }}
-                    />
-                    <button
-                      onClick={handleAddWebhook}
-                      disabled={!webhookUrl.trim() || isAddingWebhook}
-                      className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {isAddingWebhook ? "추가 중..." : "추가"}
-                    </button>
-                    <button
-                      onClick={() => {
-                        setShowWebhookInput(false);
-                        setWebhookUrl("");
-                      }}
-                      className="px-3 py-2 text-gray-500 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
-                    >
-                      취소
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => setShowWebhookInput(true)}
-                    className="flex items-center gap-2 px-4 py-2 text-sm text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors cursor-pointer"
-                  >
-                    <Plus className="w-4 h-4" />
-                    웹훅 추가
-                  </button>
-                ))}
-            </SectionContainer>
-
-            {/* 팀 탈퇴 / 삭제 섹션 */}
-            <SectionContainer
-              title={isAdmin && isAlone ? "팀 삭제" : "팀 탈퇴"}
-              subtitle={
-                isAdmin && isAlone
-                  ? "팀을 삭제하면 모든 데이터가 영구적으로 삭제됩니다."
-                  : isAdmin
-                    ? "관리자는 팀에서 탈퇴할 수 없습니다. 다른 멤버에게 관리자 권한을 넘긴 후 탈퇴해주세요."
-                    : "팀에서 탈퇴하면 더 이상 이 팀의 콘텐츠에 접근할 수 없습니다."
-              }
-            >
-              {isAdmin && isAlone ? (
-                <button
-                  onClick={() => setDeleteModalOpen(true)}
-                  className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"
-                >
-                  <Trash2 className="w-4 h-4" />팀 삭제
-                </button>
-              ) : (
-                <button
-                  onClick={handleLeaveTeam}
-                  disabled={isAdmin || leaving}
-                  className="flex items-center gap-2 px-4 py-2 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <LogOut className="w-4 h-4" />
-                  {leaving ? "탈퇴 중..." : "팀 탈퇴"}
-                </button>
-              )}
-            </SectionContainer>
+        <TeamLeaveSection
+          teamUuid={teamUuid!}
+          teamName={currentTeam?.teamName || ""}
+          isAdmin={isAdmin}
+          isAlone={isAlone}
+          onDeleteSuccess={async () => {
+            await refreshTeams();
+            navigate("/my-teams");
+          }}
+          onError={handleError}
+        />
       </div>
 
       {/* 팀 만들기 모달 */}
@@ -535,22 +180,6 @@ const SettingPage = () => {
           addTeam(newTeam);
           setIsModalOpen(false);
         }}
-      />
-
-      <TransferOwnershipModal
-        isOpen={transferModalOpen}
-        onClose={() => setTransferModalOpen(false)}
-        members={sortedMembers.filter((m) => m.role !== "owner")} // owner 제외
-        teamUuid={teamUuid!}
-        onSuccess={handleTransferSuccess}
-      />
-
-      <DeleteTeamModal
-        isOpen={deleteModalOpen}
-        onClose={() => setDeleteModalOpen(false)}
-        teamName={currentTeam?.teamName || ""}
-        teamUuid={teamUuid!}
-        onSuccess={handleDeleteSuccess}
       />
     </Layout>
   );

--- a/apps/frontend/src/pages/SettingPage.tsx
+++ b/apps/frontend/src/pages/SettingPage.tsx
@@ -131,8 +131,9 @@ const SettingPage = () => {
     <Layout sidebarProps={{ onCreateTeam: () => setIsModalOpen(true) }}>
       <h1 className="text-2xl font-bold text-gray-900 mb-8">팀 설정</h1>
 
+      {/* 에러 보여주기 */}
       {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm">
+        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm shadow-lg">
           {error}
         </div>
       )}


### PR DESCRIPTION
Closes #233 

## 개요
SettingPage.tsx가 500줄 이상으로 비대해져 유지보수성이 떨어지는 문제를 해결하기 위해 섹션별로 컴포넌트를 분리하고, 사용자 경험을 개선하는 작업을 진행했습니다.

## 주요 변경사항
### 1. 컴포넌트 분리
기존 `SettingPage.tsx`(590줄?)를 다음 섹션 컴포넌트로 분리했습니다.
- `TeamInfoSection.tsx` : 팀 이름, 생성일 표시
- `MemberSection.tsx` : 멤버 목록, 초대링크 복사, 권한 이전(오너)
- `TokenUsageSection.tsx` : ai 토큰 사용량 프로그레스 바
- `WebhookSection.tsx` : 웹훅 crud 
- `TeamLeaveSection.tsx` : 팀 탈퇴/삭제 기능
➡️ 결과적으로 SettingPage가 ~190줄로 축소되었습니다. 가독성, 유지보수성 향상

### 2. 팀원 목록 스크롤 영역 제한
팀원이 4명 이상일 경우 스크롤이 생성되도록 `max-h-[320px]` 를 적용했습니다.
<img width="761" height="454" alt="image" src="https://github.com/user-attachments/assets/0690b35d-1e5e-45c4-872c-a8e6b9026d5e" />

### 3. 에러처리 개선
에러 토스트를 생성해 화면 최상단에 고정했습니다.
웹훅 추가 실패 시에는 백엔드 에러 메시지를 표시하도록 수정했습니다.
<img width="755" height="748" alt="image" src="https://github.com/user-attachments/assets/2d49ece5-0e94-40d6-b787-ea168fdadd9a" />
