### PR TITLE
팀 가입 후 / 팀 탈퇴 후 팀 목록 갱신 바로 안되는 문제 해결

### DIFF
--- a/apps/frontend/src/components/setting/TeamLeaveSection.tsx
+++ b/apps/frontend/src/components/setting/TeamLeaveSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { LogOut, Trash2 } from "lucide-react";
 import { teamApi } from "../../services/api";
+import { useTeams } from "../../contexts/TeamContext";
 import SectionContainer from "../common/SectionContainer";
 import { DeleteTeamModal } from "./DeleteTeamModal";
 
@@ -23,6 +24,7 @@ export const TeamLeaveSection = ({
   onError,
 }: TeamLeaveSectionProps) => {
   const navigate = useNavigate();
+  const { refreshTeams } = useTeams();
   const [leaving, setLeaving] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
@@ -32,6 +34,7 @@ export const TeamLeaveSection = ({
     try {
       setLeaving(true);
       await teamApi.leaveTeam(teamUuid!);
+      await refreshTeams();
       navigate("/my-teams");
     } catch {
       onError?.("팀 탈퇴에 실패했습니다.");

--- a/apps/frontend/src/pages/InvitePage.tsx
+++ b/apps/frontend/src/pages/InvitePage.tsx
@@ -3,11 +3,13 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Users, CheckCircle } from "lucide-react";
 import { teamApi } from "../services/api";
 import { useAuth } from "../contexts/AuthContext";
+import { useTeams } from "../contexts/TeamContext";
 
 const InvitePage = () => {
   const { teamUuid } = useParams();
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { refreshTeams } = useTeams();
 
   const [teamName, setTeamName] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -59,6 +61,7 @@ const InvitePage = () => {
       setJoining(true);
       const response = await teamApi.joinTeam(teamUuid!);
       if (response.success) {
+        await refreshTeams();
         navigate(`/team/${teamUuid}`);
       } else {
         setError(response.message || "팀 가입에 실패했습니다.");


### PR DESCRIPTION
Closes #231 

## 문제상황
초대코드를 통해 팀 가입을 마친 후 my-teams로 이동하긴 하지만, 사이드바에 방금 가입한 팀 정보가 보이지 않는 문제가 있었습니다.

## 문제해결
가입 페이지에서 가입 응답으로 `예` 버튼을 누를 때 team이 갱신되지 않고 `my-teams`로 navigate만 하고 있는 상황이었습니다.
이 navigate 전에 `await refreshTeams()`를 호출해 팀 가입 후 바로 팀 목록이 갱신되도록 변경했습니다.

https://github.com/user-attachments/assets/9e7878aa-19bb-4b8b-9850-a2a1b70d50bd

같은 방식으로 팀 탈퇴 후 목록 갱신 안되던 문제도 해결했습니다
https://github.com/user-attachments/assets/197ec396-1d19-4c46-9aea-333e11c1098d


