### PR TITLE
다른 폴더를 보고있는 상태에서 새로고침시 기본 폴더로 이동되는 문제 해결

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -78,13 +78,11 @@ const Sidebar = ({
   const handleFolderClick = (folder: FolderType, team: Team) => {
     if (selectedFolderUuid === folder.folderUuid && !isSettingPage) return;
 
-    if (selectedTeamUuid === team.teamUuid && !isSettingPage) {
-      onFolderSelect?.(folder);
-    } else {
-      navigate(`/team/${team.teamUuid}`, {
-        state: { team, selectedFolderUuid: folder.folderUuid },
-      });
-    }
+    // URL에 폴더 UUID를 쿼리 파라미터로 추가하여 새로고침해도 유지되도록 함
+    navigate(`/team/${team.teamUuid}?folderUuid=${folder.folderUuid}`, {
+      state: { team, selectedFolderUuid: folder.folderUuid },
+    });
+    onFolderSelect?.(folder);
   };
 
   const handleSettingClick = (teamUuid: string) => {


### PR DESCRIPTION
Closes #240 

## 문제 상황
- 사이드바에서 폴더를 클릭하면 해당 폴더의 링크 목록이 화면에 표시되지만, url은 변경이 되지 않아 새로고침 시 기본 폴더로 이동하는 문제가 있었습니다.
- 기본 폴더로 이동하는 것은 아니고 팀 페이지로 이동하는 것인데, 팀 페이지에 기본 폴더가 기본으로 보이고 있습니다.
- 같은 팀 내에서는 폴더 클릭시에도 url을 변경하지 않고 있었습니다.

## 해결 방법
- 폴더 클릭 시에 url 에 `folderUuid` 쿼리 파라미터를 추가하도록 수정했습니다.
- 기존 `TeamPage.tsx`에서 이미 `searchParams.get("folderUuid")`로 쿼리 파라미터를 읽는 로직이 구현되어 있어 해당 로직을 활용했습니다.
- 쿼리 파라미터를 추가해 새로고침해도 유지되므로, 사용자가 선택한 폴더 상태가 보존됩니다


https://github.com/user-attachments/assets/9cb2cfdf-ec25-486e-ad2a-7ffc2ccc62e6