### PR TITLE
Fix/245 LinkCard 컴포넌트 긴 닉네임 처리

### DIFF
--- a/apps/frontend/src/components/dashboard/LinkCard.tsx
+++ b/apps/frontend/src/components/dashboard/LinkCard.tsx
@@ -92,14 +92,14 @@ const LinkCard = ({ link, onDelete, onTagClick }: LinkCardProps) => {
         )}
 
         {/* 작성자 정보 및 삭제 버튼 */}
-        <div className="flex items-center justify-between mt-auto">
-          <div className="flex items-center gap-2">
-            <div className="w-6 h-6 bg-linear-to-br from-blue-500 to-indigo-600 rounded-full flex items-center justify-center">
+        <div className="flex items-center justify-between mt-auto gap-2">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <div className="w-6 h-6 bg-linear-to-br from-blue-500 to-indigo-600 rounded-full flex items-center justify-center shrink-0">
               <span className="text-white text-xs font-bold">
                 {link.createdBy.userName.charAt(0).toUpperCase()}
               </span>
             </div>
-            <span className="text-sm text-gray-600">
+            <span className="text-sm text-gray-600 truncate">
               {link.createdBy.userName}
             </span>
           </div>
@@ -112,7 +112,7 @@ const LinkCard = ({ link, onDelete, onTagClick }: LinkCardProps) => {
                 e.stopPropagation();
                 onDelete(link.linkUuid);
               }}
-              className="p-2 hover:bg-red-50 rounded-full transition-colors cursor-pointer"
+              className="p-2 hover:bg-red-50 rounded-full transition-colors cursor-pointer shrink-0"
               title="링크 삭제"
             >
               <Trash2 className="w-4 h-4 text-gray-400 hover:text-red-500" />


### PR DESCRIPTION
## 관련 이슈
- https://github.com/boostcampwm2025/web18-lilcookie/issues/245#issuecomment-3844532498

## 작업 내용

- 외부 컨테이너: gap-2 추가 - 닉네임과 버튼 사이에 최소 간격 보장
- 닉네임 영역: flex-1 min-w-0 추가 - 남은 공간을 차지하되 넘치면 줄어들 수 있게 설정
- 아바타: shrink-0 추가 - 아바타 크기는 유지
- 닉네임 텍스트: truncate 추가 - 길면 ...으로 표시
- 삭제 버튼: shrink-0 추가 - 버튼이 항상 고정된 크기 유지

## 수정 전

<img width="335" height="412" alt="image" src="https://github.com/user-attachments/assets/78d18e8f-f86b-4754-8f7a-f2d848c4769d" />

<img width="322" height="379" alt="image" src="https://github.com/user-attachments/assets/07c19f0c-18cb-47c8-9585-07a500ee4d8c" />


## 수정 후

<img width="316" height="387" alt="image" src="https://github.com/user-attachments/assets/fdff67c4-0175-46a7-b031-d5abe22db863" />

<img width="317" height="383" alt="image" src="https://github.com/user-attachments/assets/f251f30b-edf9-4ed6-b1b5-b6d79bffc7e8" />
