### PR TITLE
설정페이지에서 폴더 생성/삭제 조작 안되는 문제 해결

### DIFF
--- a/apps/frontend/src/components/layout/Layout.tsx
+++ b/apps/frontend/src/components/layout/Layout.tsx
@@ -4,15 +4,8 @@ import Header from "./Header";
 
 interface SidebarProps {
   onCreateTeam?: () => void;
-  onCreateFolder?: (teamUuid: string) => void;
-  onDeleteFolder?: (
-    teamUuid: string,
-    folderUuid: string,
-    folderName: string,
-  ) => void;
   selectedFolderUuid?: string | null;
   onFolderSelect?: (folder: Folder) => void;
-  folderRefreshKey?: number;
 }
 
 interface HeaderProps {

--- a/apps/frontend/src/hooks/useFolders.ts
+++ b/apps/frontend/src/hooks/useFolders.ts
@@ -4,15 +4,12 @@ import type { Folder } from "../types";
 
 interface UseFoldersOptions {
   selectedTeamUuid?: string;
-  folderRefreshKey?: number;
 }
 
 // 폴더 관리를 위한 비즈니스 로직 훅
 export const useFolders = ({
   selectedTeamUuid,
-  folderRefreshKey,
 }: UseFoldersOptions) => {
-
   // 팀별 폴더 데이터 캐시
   const [teamFolders, setTeamFolders] = useState<Record<string, Folder[]>>({});
   // 이미 폴더를 조회한 팀 추적 (중복 API 호출 방지)
@@ -56,6 +53,45 @@ export const useFolders = ({
     [teamFolders],
   );
 
+  // 폴더 생성
+  // api 호출 후 성고하면 캐시(teamFolders)에 직접 추가
+  // api를 다시 호출할 필요 없이 즉시 Ui에 반영
+  const createFolder = useCallback(
+    async (teamUuid: string, folderName: string): Promise<Folder> => {
+      const response = await folderApi.createFolder({ teamUuid, folderName });
+
+      if (response.success) {
+        // 캐시에 새 폴더 추가 (API 재호출 없이 즉시 반영)
+        setTeamFolders((prev) => ({
+          ...prev,
+          [teamUuid]: [...(prev[teamUuid] || []), response.data],
+        }));
+        return response.data;
+      }
+
+      throw new Error(response.message || "폴더 생성 실패");
+    },
+    [],
+  );
+
+  // 폴더 삭제
+  // api 호출 후 성공하면 캐시(teamFolder)에서 직접 제거
+  // api를 다시 호출할 필요 없이 즉시 ui에 반영
+  const deleteFolder = useCallback(
+    async (teamUuid: string, folderUuid: string): Promise<void> => {
+      await folderApi.deleteFolder(folderUuid);
+
+      // 캐시에서 해당 폴더 제거 (API 재호출 없이 즉시 반영)
+      setTeamFolders((prev) => ({
+        ...prev,
+        [teamUuid]: (prev[teamUuid] || []).filter(
+          (f) => f.folderUuid !== folderUuid,
+        ),
+      }));
+    },
+    [],
+  );
+
   // 선택된 팀의 폴더 자동 조회 (URL 변경 시)
   useEffect(() => {
     if (!selectedTeamUuid) return;
@@ -90,39 +126,12 @@ export const useFolders = ({
     };
   }, [selectedTeamUuid, teamFolders]);
 
-  // folderRefreshKey가 변경되면 선택된 팀의 폴더 캐시 무효화 및 재조회
-  useEffect(() => {
-    if (folderRefreshKey === undefined || folderRefreshKey === 0) return;
-    if (!selectedTeamUuid) return;
-
-    // 폴더 다시 조회 (캐시 무효화 포함)
-    const refetch = async () => {
-      fetchedFoldersRef.current.delete(selectedTeamUuid);
-
-      try {
-        fetchedFoldersRef.current.add(selectedTeamUuid);
-        const response = await folderApi.getFolders(selectedTeamUuid);
-        if (response.success) {
-          setTeamFolders((prev) => ({
-            ...prev,
-            [selectedTeamUuid]: response.data,
-          }));
-        }
-      } catch (error) {
-        console.error("폴더 조회 실패:", error);
-        fetchedFoldersRef.current.delete(selectedTeamUuid);
-      }
-    };
-
-    refetch();
-    // selectedTeamUuid 변경 시에는 실행하지 않고, folderRefreshKey 변경 시에만 실행
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [folderRefreshKey]);
-
   return {
     teamFolders,
     fetchFoldersIfNeeded,
     refetchFolders,
     getFoldersByTeam,
+    createFolder,
+    deleteFolder,
   };
 };

--- a/apps/frontend/src/pages/TeamPage.tsx
+++ b/apps/frontend/src/pages/TeamPage.tsx
@@ -12,7 +12,6 @@ import { useLinks } from "../hooks";
 import type { Team, Folder as FolderType } from "../types";
 import Layout from "../components/layout/Layout";
 import CreateTeamModal from "../components/teams/CreateTeamModal";
-import CreateFolderModal from "../components/folders/CreateFolderModal";
 import LinkGrid from "../components/dashboard/LinkGrid";
 
 const TeamPage = () => {
@@ -37,13 +36,6 @@ const TeamPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isFolderModalOpen, setIsFolderModalOpen] = useState(false);
-  const [folderModalTeamUuid, setFolderModalTeamUuid] = useState<string | null>(
-    null,
-  );
-
-  // Sidebar 폴더 캐시 갱신 트리거
-  const [folderRefreshKey, setFolderRefreshKey] = useState(0);
 
   // useLinks 훅 사용
   const {
@@ -126,44 +118,6 @@ const TeamPage = () => {
     }
   };
 
-  // 폴더 생성 모달 열기
-  const handleCreateFolder = (targetTeamUuid: string) => {
-    setFolderModalTeamUuid(targetTeamUuid);
-    setIsFolderModalOpen(true);
-  };
-
-  // 폴더 삭제
-  const handleDeleteFolder = async (
-    targetTeamUuid: string,
-    folderUuid: string,
-    folderName: string,
-  ) => {
-    const confirmed = window.confirm(
-      `"${folderName}" 폴더를 삭제하시겠습니까?\n폴더 내 모든 링크도 함께 삭제됩니다.`,
-    );
-
-    if (!confirmed) return;
-
-    try {
-      await folderApi.deleteFolder(folderUuid);
-
-      // 삭제된 폴더가 현재 선택된 폴더면 기본 폴더로 이동
-      if (selectedFolder?.folderUuid === folderUuid) {
-        const foldersResponse = await folderApi.getFolders(targetTeamUuid);
-        if (foldersResponse.success && foldersResponse.data.length > 0) {
-          const firstFolder = foldersResponse.data[0];
-          setSelectedFolder(firstFolder);
-        }
-      }
-
-      // Sidebar 폴더 캐시 갱신 트리거
-      setFolderRefreshKey((prev) => prev + 1);
-    } catch (error) {
-      console.error("폴더 삭제 실패:", error);
-      alert("폴더 삭제에 실패했습니다.");
-    }
-  };
-
   if (loading) {
     return (
       <div className="flex h-screen bg-gray-50 items-center justify-center">
@@ -192,11 +146,8 @@ const TeamPage = () => {
     <Layout
       sidebarProps={{
         onCreateTeam: () => setIsModalOpen(true),
-        onCreateFolder: handleCreateFolder,
-        onDeleteFolder: handleDeleteFolder,
         selectedFolderUuid: selectedFolder?.folderUuid,
         onFolderSelect: handleFolderSelect,
-        folderRefreshKey: folderRefreshKey,
       }}
     >
       {/* 제목 */}
@@ -292,22 +243,6 @@ const TeamPage = () => {
         onTeamCreated={(newTeam) => {
           addTeam(newTeam);
           setIsModalOpen(false);
-        }}
-      />
-
-      {/* 폴더 만들기 모달 */}
-      <CreateFolderModal
-        isOpen={isFolderModalOpen}
-        teamUuid={folderModalTeamUuid}
-        onClose={() => {
-          setIsFolderModalOpen(false);
-          setFolderModalTeamUuid(null);
-        }}
-        onFolderCreated={() => {
-          setIsFolderModalOpen(false);
-          setFolderModalTeamUuid(null);
-          // Sidebar 폴더 캐시 갱신 트리거
-          setFolderRefreshKey((prev) => prev + 1);
         }}
       />
     </Layout>


### PR DESCRIPTION
Closes #215 

## 개요
설정 페이지에서 사이드바의 폴더 생성/삭제 버튼이 동작하지 않는 문제를 해결하고,
폴더 관리 아키텍처를 개선했습니다.

## 문제 상황
- 팀 설정 페이지에서 사이드바의 폴더 추가.삭제 버튼 클릭 시 아무 반응이 없었습니다.
- 폴더 생성/삭제 로직이 `TeamPage`에 있고, prop drilling으로 `Layout -> Sidebar`로 전달되는 구조였습니다.
  - `SettingPage`에서는 해당 props를 전달하지 않아 `onCreateFolder`, `onDeleteFolder`가 undefined 인 상황이었습니다.

## 해결 방법 / 변경사항
폴더 관리 로직을 `sidebar` 컴포넌트 내부로 이동해 props drilling을 제거했습니다.
### 1. useFolders 훅 확장
- `createFolder`, `deleteFolder` 함수를 추가
- api 호출 후 캐시를 직접 업데이트하여 즉시 ui 반영
- `folderRefreshKey` 제거 (캐시 직접 업데이트하기 때문에 불필요)

### 2. CreateFolderModal 개선
- `createFolder` prop추가로 useFolders 훅의 캐시 업데이트 지원
- 하위 호환성 유지 (prop 없으면 기존 로직 사용)

### 3. sidebar 리팩토링
- `useFolder` 훅에서 `createFolder`, `deleteFolder` 직접 사용
- `CreateFolderModal` 을 Sidebar 내부에서 관리
- 불필요한 props 제거

### 4. Layout, TeamPage 정리
- 폴더 관련 props 및 핸들러 제거
- `CreateFolderModal` 제거


https://github.com/user-attachments/assets/6a3421cd-27e6-4da2-a5cb-2d3adf1171a9

+추가로 다른팀의 폴더 생성/삭제 버튼 접근도 가능하도록 변경했습니다.