### PR TITLE
Feat/208 사이드바에서 폴더 이름 수정 기능 추가

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -33,10 +33,15 @@ const Sidebar = ({
   );
 
   // useFolders 훅 사용
-  const { teamFolders, fetchFoldersIfNeeded, createFolder, deleteFolder } =
-    useFolders({
-      selectedTeamUuid,
-    });
+  const {
+    teamFolders,
+    fetchFoldersIfNeeded,
+    createFolder,
+    deleteFolder,
+    renameFolder,
+  } = useFolders({
+    selectedTeamUuid,
+  });
 
   // 수동으로 펼침/접힘 토글한 팀 상태
   const [manualExpandedTeams, setManualExpandedTeams] = useState<
@@ -157,6 +162,9 @@ const Sidebar = ({
                 onCreateFolder={() => handleCreateFolderClick(team.teamUuid)}
                 onDeleteFolder={(folderUuid, folderName) =>
                   handleDeleteFolderClick(team, folderUuid, folderName)
+                }
+                onRenameFolder={(folderUuid, newName) =>
+                  renameFolder(team.teamUuid, folderUuid, newName)
                 }
                 onSettingClick={() => handleSettingClick(team.teamUuid)}
               />

--- a/apps/frontend/src/components/layout/sidebar/TeamItem.tsx
+++ b/apps/frontend/src/components/layout/sidebar/TeamItem.tsx
@@ -15,6 +15,7 @@ interface TeamItemProps {
   onFolderClick: (folder: FolderType) => void;
   onCreateFolder: () => void;
   onDeleteFolder: (folderUuid: string, folderName: string) => void;
+  onRenameFolder: (folderUuid: string, newName: string) => void;
   onSettingClick: () => void;
 }
 
@@ -30,6 +31,7 @@ const TeamItem = ({
   onFolderClick,
   onCreateFolder,
   onDeleteFolder,
+  onRenameFolder,
   onSettingClick,
 }: TeamItemProps) => {
   const [isHovered, setIsHovered] = useState(false);
@@ -148,6 +150,9 @@ const TeamItem = ({
               onClick={() => onFolderClick(folder)}
               onDelete={() =>
                 onDeleteFolder(folder.folderUuid, folder.folderName)
+              }
+              onRename={(newName) =>
+                onRenameFolder(folder.folderUuid, newName)
               }
             />
           );

--- a/apps/frontend/src/hooks/useFolders.ts
+++ b/apps/frontend/src/hooks/useFolders.ts
@@ -7,9 +7,7 @@ interface UseFoldersOptions {
 }
 
 // 폴더 관리를 위한 비즈니스 로직 훅
-export const useFolders = ({
-  selectedTeamUuid,
-}: UseFoldersOptions) => {
+export const useFolders = ({ selectedTeamUuid }: UseFoldersOptions) => {
   // 팀별 폴더 데이터 캐시
   const [teamFolders, setTeamFolders] = useState<Record<string, Folder[]>>({});
   // 이미 폴더를 조회한 팀 추적 (중복 API 호출 방지)
@@ -92,6 +90,30 @@ export const useFolders = ({
     [],
   );
 
+  // 폴더 이름 수정
+  const renameFolder = useCallback(
+    async (
+      teamUuid: string,
+      folderUuid: string,
+      newName: string,
+    ): Promise<void> => {
+      const response = await folderApi.updateFolder(folderUuid, {
+        folderName: newName,
+      });
+
+      if (response.success) {
+        // 캐시에서 해당 폴더 이름 업데이트
+        setTeamFolders((prev) => ({
+          ...prev,
+          [teamUuid]: (prev[teamUuid] || []).map((f) =>
+            f.folderUuid === folderUuid ? { ...f, folderName: newName } : f,
+          ),
+        }));
+      }
+    },
+    [],
+  );
+
   // 선택된 팀의 폴더 자동 조회 (URL 변경 시)
   useEffect(() => {
     if (!selectedTeamUuid) return;
@@ -133,5 +155,6 @@ export const useFolders = ({
     getFoldersByTeam,
     createFolder,
     deleteFolder,
+    renameFolder,
   };
 };


### PR DESCRIPTION
사이드바에서 폴더 이름을 바로 수정할 수 있는 인라인 편집 기능을 추가했습니다.

Closes #208 

## 동작 방식
1. 폴더에 마우스 호버 → 연필 아이콘 표시
2. 연필 클릭 → 텍스트가 input으로 전환, 기존 이름 자동 선택
3. Enter 또는 blur → 저장 (API 호출 + 캐시 업데이트)
4. Esc → 취소

## 작업 내용 
- useFolders 훅에 renameFolder 함수 추가
- FolderItem에 편집 UI 및 로직 추가
- TeamItem, Sidebar에 prop 연결


https://github.com/user-attachments/assets/ff742fd7-d0cf-442b-b380-2de845bdd8b2

