### PR TITLE
같은 팀 내 동일한 이름의 폴더 생성 방지

### DIFF
--- a/apps/backend/src/folders/folders.service.ts
+++ b/apps/backend/src/folders/folders.service.ts
@@ -41,6 +41,11 @@ export class FoldersService {
       throw new ConflictException("해당 폴더는 기본 폴더 이름으로, 사용할 수 없습니다.");
     }
 
+    const exists = await this.folderRepository.existsByTeamIdAndName(team.teamId, folderName);
+    if (exists) {
+      throw new ConflictException("같은 이름의 폴더가 이미 존재합니다.");
+    }
+
     const result = await this.folderRepository.create({
       teamId: team.teamId,
       folderName,

--- a/apps/backend/src/folders/repositories/folder.repository.ts
+++ b/apps/backend/src/folders/repositories/folder.repository.ts
@@ -43,6 +43,22 @@ export class FolderRepository {
   }
 
   /**
+   * 폴더 이름 중복 체크
+   * @param teamId 팀 pk
+   * @param folderName 폴더 이름
+   * @returns 해당 이름의 폴더 존재 여부
+   */
+  async existsByTeamIdAndName(teamId: number, folderName: string): Promise<boolean> {
+    const folder = await this.prisma.folder.findFirst({
+      where: {
+        teamId,
+        name: folderName,
+      },
+    });
+    return folder !== null;
+  }
+
+  /**
    * 특정 팀의 모든 폴더 조회
    * @param teamId 팀 ID
    * @returns 폴더와 해당 폴더를 생성한 사용자 정보 배열

--- a/apps/frontend/src/components/folders/CreateFolderModal.tsx
+++ b/apps/frontend/src/components/folders/CreateFolderModal.tsx
@@ -39,35 +39,30 @@ const CreateFolderModal = ({
       return;
     }
 
-    try {
-      setLoading(true);
-      setError(null);
+    setLoading(true);
+    setError(null);
 
-      // createFolder prop이 있으면 사용 (useFolders 훅의 캐시 업데이트 포함)
+    try {
       if (createFolder) {
         const folder = await createFolder(teamUuid!, folderName.trim());
         onFolderCreated(folder);
-        setFolderName("");
-        onClose();
       } else {
-        // 기존 로직 (하위 호환성)
         const response = await folderApi.createFolder({
           teamUuid: teamUuid!,
           folderName: folderName.trim(),
         });
-
-        if (response.success) {
-          onFolderCreated(response.data);
-          setFolderName("");
-          onClose();
-        } else {
-          setError(response.message || "폴더 생성에 실패했습니다.");
-        }
+        if (response.success) onFolderCreated(response.data);
+        else throw new Error(response.message);
       }
-    } catch {
-      setError("폴더 생성 중 오류가 발생했습니다.");
+      onClose();
+    } catch (err: any) {
+      const message =
+        err.response?.data?.message ||
+        err.message ||
+        "폴더 생성에 실패했습니다.";
+      setError(message);
     } finally {
-      setLoading(false);
+      setLoading(false); // 추가
     }
   };
 

--- a/apps/frontend/src/components/setting/DeleteTeamModal.tsx
+++ b/apps/frontend/src/components/setting/DeleteTeamModal.tsx
@@ -41,7 +41,7 @@ export const DeleteTeamModal = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 m-0">
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
         onClick={onClose}

--- a/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
+++ b/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
@@ -48,7 +48,7 @@ export const TransferOwnershipModal = ({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 m-0">
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
         onClick={handleClose}


### PR DESCRIPTION
Closes #263 

## 개요
- 같은 팀 내에서 동일한 이름의 폴더를 생성할 수 없도록 중복 검사 로직 추가
- 폴더 생성 모달에서 서버 에러 메시지를 사용자에게 표시하도록 개선
- ( 설정 페이지 모달 스타일 수정 )

## 주요 변경사항
### 백엔드
- `FolderRepository`에 `existsByTeamIdAndName()` 메서드 추가
- `FoldersService.create()`에서 폴더 생성 전 이름 중복 검사 수행
- 중복 시 409 Conflict 에러 반환 ("같은 이름의 폴더가 이미 존재합니다.")

### 프론트엔드
- `CreateFolderModal`: API 에러 응답 메시지를 화면에 표시하도록 에러 처리 개선
- ( `DeleteTeamModal`, `TransferOwnershipModal`: 모달 마진 스타일 수정 )


https://github.com/user-attachments/assets/bf998461-bfaa-4443-aeb4-cb02fede1826