### PR TITLE
Feat/224 팀원 강제 퇴장 기능

### DIFF
--- a/apps/backend/src/teams/teams.controller.ts
+++ b/apps/backend/src/teams/teams.controller.ts
@@ -23,7 +23,7 @@ import type { AuthenticatedUser } from "../oidc/types/oidc.types";
 import { ResponseBuilder } from "../common/builders/response.builder";
 import { WINSTON_MODULE_NEST_PROVIDER } from "nest-winston";
 import { TokenUsageService } from "./token-usage.service";
-import type { TransferOwnershipRequest } from "@repo/api";
+import type { TransferOwnershipRequest, KickMembersRequest } from "@repo/api";
 
 @Controller("teams")
 export class TeamsController {
@@ -170,6 +170,28 @@ export class TeamsController {
     return ResponseBuilder.success<Record<string, never>>()
       .status(HttpStatus.OK)
       .message("팀 소유권이 성공적으로 위임되었습니다.")
+      .data({})
+      .build();
+  }
+
+  /**
+   * 팀원 강퇴
+   * DELETE /teams/:teamUuid/members
+   */
+  @Delete(":teamUuid/members")
+  @UseGuards(OidcGuard)
+  async kickMembers(
+    @Param("teamUuid", ParseUUIDPipe) teamUuid: string,
+    @Body() dto: KickMembersRequest,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    this.logger.log(`DELETE /teams/${teamUuid}/members - 팀원 강퇴 요청`);
+
+    await this.teamsService.kickMembers(teamUuid, user.userId, dto.targetUserUuids);
+
+    return ResponseBuilder.success<Record<string, never>>()
+      .status(HttpStatus.OK)
+      .message("팀원이 성공적으로 강퇴되었습니다.")
       .data({})
       .build();
   }

--- a/apps/frontend/src/components/setting/KickMembersModal.tsx
+++ b/apps/frontend/src/components/setting/KickMembersModal.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { UserMinus, X } from "lucide-react";
+import type { GetTeamMembersResponseData } from "@repo/api";
+import { MemberSelectItem } from "./MemberSelectItem";
+import { teamApi } from "../../services/api";
+
+interface KickMembersModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  members: GetTeamMembersResponseData[]; // 전체 멤버 (owner 제외하고 넘겨주기)
+  teamUuid: string;
+  onSuccess: () => void;
+}
+
+export const KickMembersModal = ({
+  isOpen,
+  onClose,
+  members,
+  teamUuid,
+  onSuccess,
+}: KickMembersModalProps) => {
+  const [selectedMembers, setSelectedMembers] = useState<
+    GetTeamMembersResponseData[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleToggleMember = (member: GetTeamMembersResponseData) => {
+    setSelectedMembers((prev) => {
+      const isAlreadySelected = prev.some(
+        (m) => m.userUuid === member.userUuid,
+      );
+      if (isAlreadySelected) {
+        return prev.filter((m) => m.userUuid !== member.userUuid);
+      }
+      return [...prev, member];
+    });
+  };
+
+  const isSelected = (member: GetTeamMembersResponseData) => {
+    return selectedMembers.some((m) => m.userUuid === member.userUuid);
+  };
+
+  const handleKick = async () => {
+    if (selectedMembers.length === 0) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const targetUserUuids = selectedMembers.map((m) => m.userUuid);
+      await teamApi.kickMembers(teamUuid, targetUserUuids);
+
+      onSuccess();
+      onClose();
+    } catch {
+      setError("팀원 강퇴에 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    setSelectedMembers([]);
+    setError(null);
+    onClose();
+  };
+
+  const getConfirmMessage = () => {
+    if (selectedMembers.length === 0) {
+      return <span className="text-gray-400">강퇴할 팀원을 선택해주세요</span>;
+    }
+    if (selectedMembers.length === 1) {
+      return (
+        <>
+          <span className="font-semibold text-gray-900">
+            {selectedMembers[0].userName}
+          </span>
+          님을 강퇴하시겠습니까?
+        </>
+      );
+    }
+    return (
+      <>
+        <span className="font-semibold text-gray-900">
+          {selectedMembers[0].userName}
+        </span>
+        님 외 {selectedMembers.length - 1}명을 강퇴하시겠습니까?
+      </>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 m-0">
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={handleClose}
+      />
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md">
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-gray-100">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-red-100 rounded-xl flex items-center justify-center">
+              <UserMinus className="w-5 h-5 text-red-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">팀원 강퇴</h2>
+          </div>
+          <button
+            onClick={handleClose}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-5">
+          {/* 주의사항 */}
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-[13px] text-red-800">
+              강퇴된 팀원은 팀에 다시 가입할 수 있습니다.
+            </p>
+          </div>
+
+          {/* 팀원 선택 안내 */}
+          <p className="text-sm text-gray-600 mb-3">
+            강퇴할 팀원을 선택하세요 (복수 선택 가능)
+          </p>
+
+          {/* 팀원 목록 (스크롤) */}
+          <div className="max-h-48 overflow-y-auto border border-gray-200 rounded-lg mb-4">
+            {members.length === 0 ? (
+              <p className="p-4 text-sm text-gray-400 text-center">
+                강퇴할 수 있는 팀원이 없습니다.
+              </p>
+            ) : (
+              members.map((member) => (
+                <MemberSelectItem
+                  key={member.userUuid}
+                  member={member}
+                  isSelected={isSelected(member)}
+                  onSelect={handleToggleMember}
+                  colorTheme="red"
+                />
+              ))
+            )}
+          </div>
+
+          {/* 선택된 멤버 확인 */}
+          <p className="text-sm text-gray-700 mb-4 h-5">
+            {getConfirmMessage()}
+          </p>
+
+          {error && <p className="text-xs text-red-500 mb-4">{error}</p>}
+
+          {/* 버튼 */}
+          <div className="flex gap-2">
+            <button
+              onClick={handleClose}
+              disabled={loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors disabled:opacity-50 cursor-pointer"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleKick}
+              disabled={selectedMembers.length === 0 || loading}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-red-600 rounded-xl hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            >
+              {loading ? "강퇴 중..." : `강퇴 (${selectedMembers.length}명)`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/setting/MemberSection.tsx
+++ b/apps/frontend/src/components/setting/MemberSection.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo } from "react";
-import { Users, Copy, Check, Crown } from "lucide-react";
+import { Users, Copy, Check, Crown, UserMinus } from "lucide-react";
 import type { GetTeamMembersResponseData } from "@repo/api";
 import SectionContainer from "../common/SectionContainer";
 import { TransferOwnershipModal } from "./TransferOwnershipModal";
+import { KickMembersModal } from "./KickMembersModal";
 
 interface MemberSectionProps {
   members: GetTeamMembersResponseData[];
@@ -23,6 +24,7 @@ export const MemberSection = ({
 }: MemberSectionProps) => {
   const [copied, setCopied] = useState(false);
   const [transferModalOpen, setTransferModalOpen] = useState(false);
+  const [kickModalOpen, setKickModalOpen] = useState(false);
 
   const sortedMembers = useMemo(() => {
     return [...members].sort((a, b) => {
@@ -52,13 +54,22 @@ export const MemberSection = ({
         headerAction={
           <div className="flex gap-2">
             {isAdmin && members.length > 1 && (
-              <button
-                onClick={() => setTransferModalOpen(true)}
-                className="flex items-center gap-2 px-3 py-1.5 text-sm text-amber-600 border border-amber-200 rounded-lg hover:bg-amber-50 transition-colors cursor-pointer"
-              >
-                <Crown className="w-4 h-4" />
-                권한 위임
-              </button>
+              <>
+                <button
+                  onClick={() => setKickModalOpen(true)}
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors cursor-pointer"
+                >
+                  <UserMinus className="w-4 h-4" />
+                  강퇴
+                </button>
+                <button
+                  onClick={() => setTransferModalOpen(true)}
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm text-amber-600 border border-amber-200 rounded-lg hover:bg-amber-50 transition-colors cursor-pointer"
+                >
+                  <Crown className="w-4 h-4" />
+                  권한 위임
+                </button>
+              </>
             )}
             <button
               onClick={handleCopyInviteLink}
@@ -124,6 +135,14 @@ export const MemberSection = ({
       <TransferOwnershipModal
         isOpen={transferModalOpen}
         onClose={() => setTransferModalOpen(false)}
+        members={sortedMembers.filter((m) => m.role !== "owner")}
+        teamUuid={teamUuid}
+        onSuccess={onTransferSuccess}
+      />
+
+      <KickMembersModal
+        isOpen={kickModalOpen}
+        onClose={() => setKickModalOpen(false)}
         members={sortedMembers.filter((m) => m.role !== "owner")}
         teamUuid={teamUuid}
         onSuccess={onTransferSuccess}

--- a/apps/frontend/src/components/setting/MemberSelectItem.tsx
+++ b/apps/frontend/src/components/setting/MemberSelectItem.tsx
@@ -1,0 +1,47 @@
+import { Check } from "lucide-react";
+import type { GetTeamMembersResponseData } from "@repo/api";
+
+export type ColorTheme = "amber" | "red";
+
+interface MemberSelectItemProps {
+  member: GetTeamMembersResponseData;
+  isSelected: boolean;
+  onSelect: (member: GetTeamMembersResponseData) => void;
+  colorTheme?: ColorTheme;
+}
+
+const themeStyles: Record<ColorTheme, { selected: string; checkIcon: string }> =
+  {
+    amber: {
+      selected: "bg-amber-50",
+      checkIcon: "text-amber-600",
+    },
+    red: {
+      selected: "bg-red-50",
+      checkIcon: "text-red-600",
+    },
+  };
+
+export const MemberSelectItem = ({
+  member,
+  isSelected,
+  onSelect,
+  colorTheme = "amber",
+}: MemberSelectItemProps) => {
+  const styles = themeStyles[colorTheme];
+
+  return (
+    <button
+      onClick={() => onSelect(member)}
+      className={`w-full flex items-center justify-between p-3 hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-b-0 cursor-pointer ${
+        isSelected ? styles.selected : ""
+      }`}
+    >
+      <div className="flex flex-col items-start">
+        <span className="font-medium text-gray-900">{member.userName}</span>
+        <span className="text-xs text-gray-500">{member.userEmail}</span>
+      </div>
+      {isSelected && <Check className={`w-5 h-5 ${styles.checkIcon}`} />}
+    </button>
+  );
+};

--- a/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
+++ b/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { Crown, X, Check } from "lucide-react";
+import { Crown, X } from "lucide-react";
 import { teamApi } from "../../services/api";
 import type { GetTeamMembersResponseData } from "@repo/api";
+import { MemberSelectItem } from "./MemberSelectItem";
 
 interface TransferOwnershipModalProps {
   isOpen: boolean;
@@ -47,6 +48,10 @@ export const TransferOwnershipModal = ({
     onClose();
   };
 
+  const handleSelectMember = (member: GetTeamMembersResponseData) => {
+    setSelectedMember(member);
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 m-0">
       <div
@@ -64,7 +69,7 @@ export const TransferOwnershipModal = ({
           </div>
           <button
             onClick={handleClose}
-            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
           >
             <X className="w-4 h-4" />
           </button>
@@ -93,27 +98,13 @@ export const TransferOwnershipModal = ({
               </p>
             ) : (
               members.map((member) => (
-                <button
+                <MemberSelectItem
                   key={member.userUuid}
-                  onClick={() => setSelectedMember(member)}
-                  className={`w-full flex items-center justify-between p-3 hover:bg-gray-50 transition-colors border-b border-gray-100 last:border-b-0 ${
-                    selectedMember?.userUuid === member.userUuid
-                      ? "bg-amber-50"
-                      : ""
-                  }`}
-                >
-                  <div className="flex flex-col items-start">
-                    <span className="font-medium text-gray-900">
-                      {member.userName}
-                    </span>
-                    <span className="text-xs text-gray-500">
-                      {member.userEmail}
-                    </span>
-                  </div>
-                  {selectedMember?.userUuid === member.userUuid && (
-                    <Check className="w-5 h-5 text-amber-600" />
-                  )}
-                </button>
+                  member={member}
+                  isSelected={selectedMember?.userUuid === member.userUuid}
+                  onSelect={handleSelectMember}
+                  colorTheme="amber"
+                />
               ))
             )}
           </div>

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -346,6 +346,16 @@ export const teamApi = {
     });
   },
 
+  // DELETE /teams/:teamUuid/members - 팀원 강퇴
+  kickMembers: async (
+    teamUuid: string,
+    targetUserUuids: string[],
+  ): Promise<void> => {
+    await api.delete(`teams/${teamUuid}/members`, {
+      data: { targetUserUuids },
+    });
+  },
+
   // DELETE /teams/:teamUuid/delete - 팀 삭제
   deleteTeam: async (teamUuid: string): Promise<void> => {
     await api.delete(`teams/${teamUuid}/delete`);

--- a/packages/api/src/teams/team.schema.ts
+++ b/packages/api/src/teams/team.schema.ts
@@ -51,3 +51,8 @@ export const GetTeamTokenUsageResponseDataSchema = z.object({
 export const TransferOwnershipRequestSchema = z.object({
   targetUserUuid: z.string().uuid(),
 });
+
+/** 팀원 강퇴 요청 */
+export const KickMembersRequestSchema = z.object({
+  targetUserUuids: z.array(z.string().uuid()).min(1),
+});

--- a/packages/api/src/teams/team.type.ts
+++ b/packages/api/src/teams/team.type.ts
@@ -8,23 +8,15 @@ import {
   PreviewTeamRespondDataSchema,
   TeamResponseDataSchema,
   TransferOwnershipRequestSchema,
+  KickMembersRequestSchema,
 } from "./team.schema.js";
 
 export type CreateTeamRequest = z.infer<typeof CreateTeamRequestSchema>;
 export type TeamResponseData = z.infer<typeof TeamResponseDataSchema>;
-export type PreviewTeamResponeData = z.infer<
-  typeof PreviewTeamRespondDataSchema
->;
+export type PreviewTeamResponeData = z.infer<typeof PreviewTeamRespondDataSchema>;
 export type JoinTeamResponseData = z.infer<typeof JoinTeamResponseDataSchema>;
-export type GetTeamMembersResponseData = z.infer<
-  typeof GetTeamMembersResponsedDataSchema
->;
-export type GetTeamWebhooksResponseData = z.infer<
-  typeof GetTeamWebhooksResponseDataSchema
->;
-export type GetTeamTokenUsageResponseData = z.infer<
-  typeof GetTeamTokenUsageResponseDataSchema
->;
-export type TransferOwnershipRequest = z.infer<
-  typeof TransferOwnershipRequestSchema
->;
+export type GetTeamMembersResponseData = z.infer<typeof GetTeamMembersResponsedDataSchema>;
+export type GetTeamWebhooksResponseData = z.infer<typeof GetTeamWebhooksResponseDataSchema>;
+export type GetTeamTokenUsageResponseData = z.infer<typeof GetTeamTokenUsageResponseDataSchema>;
+export type TransferOwnershipRequest = z.infer<typeof TransferOwnershipRequestSchema>;
+export type KickMembersRequest = z.infer<typeof KickMembersRequestSchema>;


### PR DESCRIPTION
## 관련 이슈

- close #224 

## 변경내용

### Backend
- `DELETE /teams/:teamUuid/members` API 엔드포인트 추가
- 다중 사용자 강퇴 지원 (`targetUserUuids: string[]`)
- 권한 검증: owner만 강퇴 가능, 자기 자신/owner 강퇴 불가

### Frontend
- `KickMembersModal`: 다중 선택 강퇴 모달 (red 테마)
- `MemberSelectItem`: 공통 멤버 선택 컴포넌트 분리
- `MemberSection`: 강퇴 버튼 추가
- `TransferOwnershipModal`: 공통 컴포넌트 사용하도록 리팩토링

### API 스키마
- `KickMembersRequestSchema` 추가
- `KickMembersRequest` 타입 export

- 기존 아현님이 작업하신 권한 위임 모달과 매우 유사하게 작업했습니다. (재활용)
- 그 중에서 중복이 있는 부분 (극히 일부분)을 컴포넌트로 뽑았습니다.

## 스크린샷

![bye](https://github.com/user-attachments/assets/792432b8-2bb1-40f1-8685-ba4cb6d338ca)
