### PR TITLE
Fix/271 팀 전환 시 잘못된 링크 API 호출로 인한 400 에러 수정

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -84,7 +84,12 @@ const Sidebar = ({
     navigate(`/team/${team.teamUuid}?folderUuid=${folder.folderUuid}`, {
       state: { team, selectedFolderUuid: folder.folderUuid },
     });
-    onFolderSelect?.(folder);
+
+    // 같은 팀의 폴더를 클릭한 경우에만 즉시 반영
+    // 다른 팀의 폴더를 클릭한 경우 네비게이션 후 TeamPage에서 처리
+    if (team.teamUuid === selectedTeamUuid) {
+      onFolderSelect?.(folder);
+    }
   };
 
   const handleSettingClick = (teamUuid: string) => {

--- a/apps/frontend/src/pages/TeamPage.tsx
+++ b/apps/frontend/src/pages/TeamPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   useParams,
   useNavigate,
@@ -37,6 +37,21 @@ const TeamPage = () => {
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  // 이전 teamUuid를 추적하여 팀 변경 감지
+  const prevTeamUuidRef = useRef(teamUuid);
+
+  // teamUuid가 변경되면 selectedFolder 초기화 (잘못된 API 호출 방지)
+  useEffect(() => {
+    setSelectedFolder(null);
+    prevTeamUuidRef.current = teamUuid;
+  }, [teamUuid]);
+
+  // 팀이 변경 중이면 folderUuid를 undefined로 전달 (렌더링 중에 체크)
+  const isTeamChanging = prevTeamUuidRef.current !== teamUuid;
+  const folderUuidForLinks = isTeamChanging
+    ? undefined
+    : selectedFolder?.folderUuid;
+
   // useLinks 훅 사용
   const {
     links,
@@ -51,7 +66,7 @@ const TeamPage = () => {
     clearTags: handleClearTags,
   } = useLinks({
     teamUuid,
-    folderUuid: selectedFolder?.folderUuid,
+    folderUuid: folderUuidForLinks,
   });
 
   // 팀 및 폴더 정보 조회 (팀이 변경될 때만)


### PR DESCRIPTION

팀 간 이동 시 네트워크 탭에서 400 에러가 발생하는 버그를 수정했습니다.
- 에러 메시지: 해당 팀에 속해있는 폴더가 아닙니다

Closes #271 

## 케이스 1: A팀 -> B팀 클릭

### 문제 상황
사이드바에서 B팀을 클릭해서 B팀으로 이동할 때 발생

### 원인
- B팀 클릭 -> `navigate()` 실행 -> URL이 `/team/bbb`로 변경
- TeamPage 리렌더링 -> `teamUuid`는 URL에서 가져오니까 즉시 `"bbb"`로 변경
- 하지만 `selectedFolder`는 React state라서 아직 A팀 폴더(`"111"`) 유지
- `useLinks`가 `teamUuid: "bbb"` + `folderUuid: "111"` 조합으로 API 호출 -> **400 에러**

### 해결 (TeamPage.tsx)
- useRef로 이전 teamUuid를 저장해두고, 팀이 변경 중이면 folderUuid를 undefined로 전달(useLinks는 folderUuid가 없으면 API를 호출하지 않으니까)

## 케이스 2: A팀 페이지에서 B팀 폴더 클릭
### 문제 상황
A팀 페이지에 있는데, 사이드바에서 B팀의 폴더를 클릭할 때 발생

### 원인
- B팀 폴더 클릭 -> `navigate()` 실행 (URL 변경은 예약만 됨, 아직 안 바뀜)
- 바로 다음 줄 `onFolderSelect()` 실행 -> `selectedFolder`가 B팀 폴더(`"222"`)로 변경
- 아직 A팀 페이지인 상태 (`teamUuid`는 여전히 "aaa")
- `useLinks`가 `teamUuid: "aaa" + folderUuid: "222"` 조합으로 API 호출 -> **400 에러**

### 해결 (Sidebar.tsx)
- 클릭한 폴더가 현재 팀의 폴더일 때만 onFolderSelect()를 호출
- 다른 팀의 폴더를 클릭한 경우에는 네비게이션 완료 후 TeamPage에서 폴더가 설정됨