### PR TITLE
ESC 키로 모달 닫기

### DIFF
--- a/apps/frontend/src/components/folders/CreateFolderModal.tsx
+++ b/apps/frontend/src/components/folders/CreateFolderModal.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { X, FolderPlus } from "lucide-react";
 import { folderApi } from "../../services/api";
 import type { Folder } from "../../types";
+import { useEscapeKey } from "../../hooks";
 
 interface CreateFolderModalProps {
   isOpen: boolean;
@@ -23,11 +24,19 @@ const CreateFolderModal = ({
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const handleClose = useCallback(() => {
+    setFolderName("");
+    setError(null);
+    onClose();
+  }, [onClose]);
+
   useEffect(() => {
     if (isOpen) {
       inputRef.current?.focus();
     }
   }, [isOpen]);
+
+  useEscapeKey(isOpen, handleClose);
 
   if (!isOpen || !teamUuid) return null;
 
@@ -64,12 +73,6 @@ const CreateFolderModal = ({
     } finally {
       setLoading(false); // 추가
     }
-  };
-
-  const handleClose = () => {
-    setFolderName("");
-    setError(null);
-    onClose();
   };
 
   return (

--- a/apps/frontend/src/components/setting/DeleteTeamModal.tsx
+++ b/apps/frontend/src/components/setting/DeleteTeamModal.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Trash2, X } from "lucide-react";
 import { teamApi } from "../../services/api";
+import { useEscapeKey } from "../../hooks";
 
 interface DeleteTeamModalProps {
   isOpen: boolean;
@@ -21,6 +22,14 @@ export const DeleteTeamModal = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClose = useCallback(() => {
+    setInputValue("");
+    setError(null);
+    onClose();
+  }, [onClose]);
+
+  useEscapeKey(isOpen, handleClose);
 
   if (!isOpen) return null;
 
@@ -44,7 +53,7 @@ export const DeleteTeamModal = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 m-0">
       <div
         className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-        onClick={onClose}
+        onClick={handleClose}
       />
       <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md">
         {/* Header */}
@@ -56,7 +65,7 @@ export const DeleteTeamModal = ({
             <h2 className="text-lg font-semibold text-gray-900">팀 삭제</h2>
           </div>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
           >
             <X className="w-4 h-4" />
@@ -102,7 +111,7 @@ export const DeleteTeamModal = ({
 
           <div className="flex gap-2">
             <button
-              onClick={onClose}
+              onClick={handleClose}
               disabled={loading}
               className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors disabled:opacity-50"
             >

--- a/apps/frontend/src/components/setting/KickMembersModal.tsx
+++ b/apps/frontend/src/components/setting/KickMembersModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { UserMinus, X } from "lucide-react";
 import type { GetTeamMembersResponseData } from "@repo/api";
 import { MemberSelectItem } from "./MemberSelectItem";
 import { teamApi } from "../../services/api";
+import { useEscapeKey } from "../../hooks";
 
 interface KickMembersModalProps {
   isOpen: boolean;
@@ -24,6 +25,14 @@ export const KickMembersModal = ({
   >([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const handleClose = useCallback(() => {
+    setSelectedMembers([]);
+    setError(null);
+    onClose();
+  }, [onClose]);
+
+  useEscapeKey(isOpen, handleClose);
 
   if (!isOpen) return null;
 
@@ -60,12 +69,6 @@ export const KickMembersModal = ({
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleClose = () => {
-    setSelectedMembers([]);
-    setError(null);
-    onClose();
   };
 
   const getConfirmMessage = () => {

--- a/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
+++ b/apps/frontend/src/components/setting/TransferOwnershipModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Crown, X } from "lucide-react";
 import { teamApi } from "../../services/api";
 import type { GetTeamMembersResponseData } from "@repo/api";
 import { MemberSelectItem } from "./MemberSelectItem";
+import { useEscapeKey } from "../../hooks";
 
 interface TransferOwnershipModalProps {
   isOpen: boolean;
@@ -24,6 +25,14 @@ export const TransferOwnershipModal = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const handleClose = useCallback(() => {
+    setSelectedMember(null);
+    setError(null);
+    onClose();
+  }, [onClose]);
+
+  useEscapeKey(isOpen, handleClose);
+
   if (!isOpen) return null;
 
   const handleTransfer = async () => {
@@ -40,12 +49,6 @@ export const TransferOwnershipModal = ({
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleClose = () => {
-    setSelectedMember(null);
-    setError(null);
-    onClose();
   };
 
   const handleSelectMember = (member: GetTeamMembersResponseData) => {

--- a/apps/frontend/src/components/teams/CreateTeamModal.tsx
+++ b/apps/frontend/src/components/teams/CreateTeamModal.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Users } from "lucide-react";
 import { teamApi } from "../../services/api";
 import type { Team } from "../../types";
+import { useEscapeKey } from "../../hooks";
 
 // TODO: 백엔드 연동 시 제거
 const USE_MOCK_DATA = false;
@@ -21,6 +22,14 @@ const CreateTeamModal = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClose = useCallback(() => {
+    setTeamName("");
+    setError(null);
+    onClose();
+  }, [onClose]);
+
+  useEscapeKey(isOpen, handleClose);
 
   useEffect(() => {
     if (isOpen) {
@@ -68,12 +77,6 @@ const CreateTeamModal = ({
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleClose = () => {
-    setTeamName("");
-    setError(null);
-    onClose();
   };
 
   return (

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useLinks } from "./useLinks";
 export { useFolders } from "./useFolders";
+export { useEscapeKey } from "./useEscapeKey";

--- a/apps/frontend/src/hooks/useEscapeKey.ts
+++ b/apps/frontend/src/hooks/useEscapeKey.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+export const useEscapeKey = (isOpen: boolean, onClose: () => void) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+};


### PR DESCRIPTION
Closes #272 

## 개요
- 모달 UX 개선: ESC 키로 모달 닫기 기능 추가
- 재사용 가능한 `useEscapeKey` 커스텀 훅 추가

## 주요 변경사항
- `hooks/useEscapeKey.ts` 추가 : ESC 키 이벤트를 감지하여 모달을 닫는 커스텀 훅
  - 여러 모달 컴포넌트에서 재사용하기 위해 커스텀 훅으로 추출했습니다.
- 각 모달들에서 `useEscapeKey` 적용

⬇️ ESC로 잘 닫힙니다!

https://github.com/user-attachments/assets/5e08b306-c0b8-47aa-8bb9-afc7e2d53c38

