### PR TITLE
Fix/274 링크 카드 UX 개선

### DIFF
--- a/apps/frontend/src/components/dashboard/LinkCard.tsx
+++ b/apps/frontend/src/components/dashboard/LinkCard.tsx
@@ -67,7 +67,7 @@ const LinkCard = ({ link, onDelete, onTagClick }: LinkCardProps) => {
 
         {/* 요약 */}
         {link.summary && (
-          <p className="text-sm text-gray-600 mb-3 line-clamp-2 leading-relaxed">
+          <p className="text-sm text-gray-600 mb-3 line-clamp-8 leading-relaxed">
             {link.summary}
           </p>
         )}

--- a/apps/frontend/src/components/dashboard/LinkGrid.tsx
+++ b/apps/frontend/src/components/dashboard/LinkGrid.tsx
@@ -15,8 +15,8 @@ const LinkGrid = ({
   onDeleteLink,
   onTagClick,
 }: LinkGridProps) => {
-  // 로딩 중
-  if (loading) {
+  // 로딩 중 + 기존 데이터 없을 때만 스켈레톤 표시
+  if (loading && links.length === 0) {
     return (
       <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
         {[1, 2, 3, 4, 5, 6].map((i) => (


### PR DESCRIPTION
Closes #274 

## 작업 내용
- 링크 카드 요약 200자 전체 표시 (#274)
  - `LinkCard.tsx`: 요약 line-clamp-2 → line-clamp-8
- 폴더 전환 시 스켈레톤 깜빡임 감소
  - `LinkGrid.tsx`: 기존 데이터 있을 때 스켈레톤 미표시

<img width="1067" height="662" alt="image" src="https://github.com/user-attachments/assets/fd7db7b1-f695-44af-928e-70333a07ec3b" />
