### PR TITLE
Fix/277 OAuth 연동시 노출되는 엔드포인트 수정

### DIFF
--- a/apps/frontend/src/pages/OAuthApps.tsx
+++ b/apps/frontend/src/pages/OAuthApps.tsx
@@ -389,18 +389,65 @@ const OAuthApps = () => {
               </div>
 
               <div className="mt-6 pt-4 border-t border-gray-100">
-                <h4 className="text-sm font-medium text-gray-700 mb-2">Authentik 엔드포인트</h4>
-                <div className="space-y-2 text-xs text-gray-600">
-                  <div className="flex items-center gap-2">
-                    <ExternalLink className="w-3 h-3" />
-                    <span>Authorization URL:</span>
-                    <code className="bg-gray-100 px-1.5 py-0.5 rounded">/application/o/authorize/</code>
+                <h4 className="text-sm font-medium text-gray-700 mb-3">OAuth 엔드포인트</h4>
+                <div className="space-y-3">
+                  <div>
+                    <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Authorization URL
+                    </label>
+                    <div className="flex items-center gap-2 mt-1">
+                      <code className="flex-1 px-3 py-2 bg-gray-50 rounded-lg text-xs font-mono text-gray-700 break-all">
+                        https://auth.teamstash.eupthere.uk/application/o/authorize/
+                      </code>
+                      <button
+                        onClick={() =>
+                          handleCopy("https://auth.teamstash.eupthere.uk/application/o/authorize/", "auth-url")
+                        }
+                        className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer shrink-0"
+                      >
+                        {copiedField === "auth-url" ? (
+                          <Check className="w-4 h-4 text-green-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <ExternalLink className="w-3 h-3" />
-                    <span>Token URL:</span>
-                    <code className="bg-gray-100 px-1.5 py-0.5 rounded">/application/o/token/</code>
+
+                  <div>
+                    <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Access Token URL
+                    </label>
+                    <div className="flex items-center gap-2 mt-1">
+                      <code className="flex-1 px-3 py-2 bg-gray-50 rounded-lg text-xs font-mono text-gray-700 break-all">
+                        https://auth.teamstash.eupthere.uk/application/o/token/
+                      </code>
+                      <button
+                        onClick={() =>
+                          handleCopy("https://auth.teamstash.eupthere.uk/application/o/token/", "token-url")
+                        }
+                        className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer shrink-0"
+                      >
+                        {copiedField === "token-url" ? (
+                          <Check className="w-4 h-4 text-green-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
                   </div>
+                </div>
+
+                <div className="mt-4 p-3 bg-blue-50 rounded-lg">
+                  <a
+                    href="https://docs.teamstash.eupthere.uk/integrations-and-api/n8n-Integration-Guide.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-between text-sm text-blue-700 hover:text-blue-800 transition-colors"
+                  >
+                    <span>🔗 연동 가이드 보기</span>
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
                 </div>
               </div>
 


### PR DESCRIPTION
## 관련 이슈

- close #277 

## 작업 내용

- Authorization URL 및 Access Token URL 수정
- URL 복사 기능
- 연동 가이드 링크 추가

## 스크린샷

<img width="521" height="694" alt="image" src="https://github.com/user-attachments/assets/a6ba3ab7-275d-438b-838a-1e66ce969f38" />

## 여담

기존에 제가 프리티어 width 120로 작업한 부분이라서, diff를 줄이기위해 120으로 작업했습니다.

기존 `Authentik 엔드포인트` 이거보다 `OAuth 엔드포인트`가 더 적합하다고 판단되어서 수정했습니다.