### PR TITLE
확장프로그램 알림 클릭 시 `/my-teams` path로 연결

### DIFF
--- a/apps/extension-wxt/entrypoints/background/notifications.background.ts
+++ b/apps/extension-wxt/entrypoints/background/notifications.background.ts
@@ -25,7 +25,7 @@ export function setupNotificationHandlers() {
       const authState = await getAuthState();
       if (authState.isLoggedIn && authState.userInfo?.selectedTeamUuid) {
         chrome.tabs.create({
-          url: `${FE_BASE_URL}/${authState.userInfo.selectedTeamUuid.toLowerCase()}`,
+          url: `${FE_BASE_URL}/my-teams`,
         });
       }
       chrome.notifications.clear(notificationId);


### PR DESCRIPTION
## 관련 이슈
#286

## 주요 작업
대시보드에 팀, 폴더가 추가되며 URL이 변경됨. 알림은 여러 팀 내용이 함께 집계되므로, 사용자의 혼란을 방지하기 위해 `/my-teams` 패스로 연결. 추후 대시보드에 알림 확인 팝업 추가하여 UX 개선 가능해 보임.