### PR TITLE
Fix/292 페이지 전환·새로고침 시에도 사이드바 펼침 상태 유지

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@repo/api": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "axios": "^1.13.2",
     "axios-retry": "^4.5.0",
@@ -19,7 +20,7 @@
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.10.1",
     "tailwindcss": "^4.1.18",
-    "@repo/api": "workspace:*"
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { Users } from "lucide-react";
 import type { Team, Folder as FolderType } from "../../types";
 import { useTeams } from "../../contexts/TeamContext";
 import { useFolders } from "../../hooks";
+import { useSidebarStore } from "../../stores/sidebar.store";
 import TeamItem from "./sidebar/TeamItem";
 import CreateFolderModal from "../folders/CreateFolderModal";
 
@@ -43,10 +44,9 @@ const Sidebar = ({
     selectedTeamUuid,
   });
 
-  // 수동으로 펼침/접힘 토글한 팀 상태
-  const [manualExpandedTeams, setManualExpandedTeams] = useState<
-    Record<string, boolean>
-  >({});
+  // 수동으로 펼침/접힘 토글한 팀 상태 (localStorage 영속)
+  const manualExpandedTeams = useSidebarStore((s) => s.manualExpandedTeams);
+  const setTeamExpanded = useSidebarStore((s) => s.setTeamExpanded);
 
   // 팀이 펼쳐져 있는지 계산 (수동 상태 우선, 없으면 선택된 팀만 펼침)
   const isTeamExpanded = (teamUuid: string): boolean => {
@@ -63,10 +63,7 @@ const Sidebar = ({
     const currentlyExpanded = isTeamExpanded(teamUuid);
     const willExpand = !currentlyExpanded;
 
-    setManualExpandedTeams((prev) => ({
-      ...prev,
-      [teamUuid]: willExpand,
-    }));
+    setTeamExpanded(teamUuid, willExpand);
 
     if (willExpand) {
       await fetchFoldersIfNeeded(teamUuid);

--- a/apps/frontend/src/stores/sidebar.store.ts
+++ b/apps/frontend/src/stores/sidebar.store.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface SidebarState {
+  manualExpandedTeams: Record<string, boolean>;
+  setTeamExpanded: (teamUuid: string, expanded: boolean) => void;
+}
+
+export const useSidebarStore = create<SidebarState>()(
+  persist(
+    (set) => ({
+      manualExpandedTeams: {},
+      setTeamExpanded: (teamUuid, expanded) =>
+        set((state) => ({
+          manualExpandedTeams: {
+            ...state.manualExpandedTeams,
+            [teamUuid]: expanded,
+          },
+        })),
+    }),
+    { name: "sidebar-state" },
+  ),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.8)(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -6379,6 +6382,24 @@ packages:
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -12985,5 +13006,10 @@ snapshots:
       zod: 4.3.5
 
   zod@4.3.5: {}
+
+  zustand@5.0.14(@types/react@19.2.8)(react@19.2.3):
+    optionalDependencies:
+      '@types/react': 19.2.8
+      react: 19.2.3
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## 관련 이슈

Closes #292 

---

사이드바에서 펼쳐 둔 팀들이 페이지를 옮기거나 새로고침하면 전부 다시 접혀 버리는 문제가 있었습니다. 원인은 펼침 상태(`manualExpandedTeams`)가 Sidebar 컴포넌트의 로컬 `useState`로만 관리되고 있어서, Sidebar가 unmount되거나 새로고침되면 그대로 사라지는 구조였기 때문이었습니다.

따라서 이 상태를 Zustand `persist` middleware로 옮겨, localStorage에 자동으로 동기화되도록 바꿨습니다.

## 작업한 내용

- 사이드바 영속 상태용 store 파일(`apps/frontend/src/stores/sidebar.store.ts`) 추가. `manualExpandedTeams` state + `setTeamExpanded` 액션 한 개, `persist` middleware가 localStorage `sidebar-state` 키에 자동 저장
- `Sidebar.tsx`의 로컬 `useState` 제거 후 store selector로 전환, `setManualExpandedTeams` 호출도 `setTeamExpanded`로 단순화
- `zustand` 의존성 추가

## 왜 Zustand persist인가

영속이 필요한 클라이언트 UI 상태에서 가장 표준적인 답이고 직접 `useState + useEffect`로 localStorage 동기화를 구현할 수도 있지만, read-modify-write 패턴이라 race condition 위험이 있고 보일러플레이트도 늘어남. Zustand persist middleware가 hydration과 자동 저장을 모두 처리해 줘서 같은 데이터를 여러 컴포넌트가 동시에 접근해도 안전함.

## 검증 시나리오

- [ ] 사이드바에서 팀을 펼친 뒤 다른 페이지에 다녀와도 펼침 유지
- [ ] 팀을 펼친 뒤 새로고침해도 펼침 유지
- [ ] DevTools → Application → Local Storage에 `sidebar-state` 키 생성 확인
- [ ] 다른 팀을 선택해도 기존에 펼친 팀들은 그대로 유지 (기존 로직 회귀 없음)