### PR TITLE
Fix/294 useLinks를 TanStack Query로 마이그레이션해 폴더 전환 깜빡임 제거

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@repo/api": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/react-query": "^5.101.0",
     "axios": "^1.13.2",
     "axios-retry": "^4.5.0",
     "lucide-react": "^0.561.0",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@tanstack/react-query-devtools": "^5.101.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import TeamPage from "./pages/TeamPage";
@@ -11,11 +13,23 @@ import SettingPage from "./pages/SettingPage";
 import MyPage from "./pages/MyPage";
 import { TeamsProvider } from "./contexts/TeamContext";
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000, // 5분 동안 fresh로 유지 (재방문 시 캐시 즉시 표시)
+      gcTime: 10 * 60 * 1000, // 10분 후 미사용 캐시 제거
+      refetchOnWindowFocus: false, // 윈도우 포커스 시 자동 refetch 비활성화
+      retry: 1, // 실패 시 1회만 재시도
+    },
+  },
+});
+
 function App() {
   return (
-    <BrowserRouter>
-      <AuthProvider>
-        <TeamsProvider>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider>
+          <TeamsProvider>
           <Routes>
             {/* 루트 경로 - 내 팀 페이지로 리다이렉트 */}
             <Route path="/" element={<Navigate to="/my-teams" replace />} />
@@ -87,6 +101,8 @@ function App() {
         </TeamsProvider>
       </AuthProvider>
     </BrowserRouter>
+    <ReactQueryDevtools initialIsOpen={false} />
+  </QueryClientProvider>
   );
 }
 

--- a/apps/frontend/src/hooks/useLinks.ts
+++ b/apps/frontend/src/hooks/useLinks.ts
@@ -1,4 +1,5 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { linkApi } from "../services/api";
 import type { Link } from "../types";
 
@@ -8,70 +9,63 @@ interface UseLinksOptions {
 }
 
 // 링크 관리 훅
+// 서버 상태(links, loading, error)는 TanStack Query로,
+// 클라이언트 UI 상태(selectedTags, searchQuery)는 useState로 분리해 관리한다.
 export const useLinks = ({ teamUuid, folderUuid }: UseLinksOptions) => {
+  const queryClient = useQueryClient();
 
-  const [links, setLinks] = useState<Link[]>([]);
-
-  const [loading, setLoading] = useState(false);
-
-  const [error, setError] = useState<string | null>(null);
-
+  // 클라이언트 UI 상태
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-
   const [searchQuery, setSearchQuery] = useState("");
 
-  // 링크 목록 조회
-  const fetchLinks = useCallback(async () => {
-    if (!teamUuid || !folderUuid) return;
+  // 서버 상태 — 같은 (team, folder, tags) 조합은 staleTime 동안 캐시 사용
+  const queryKey = ["links", teamUuid, folderUuid, selectedTags] as const;
 
-    setLoading(true);
-    setError(null);
-
-    try {
+  const {
+    data: links = [],
+    isLoading: loading,
+    error: queryError,
+    refetch,
+  } = useQuery({
+    queryKey,
+    queryFn: async () => {
       const options: {
         teamUuid: string;
         folderUuid?: string;
         tags?: string[];
       } = {
-        teamUuid,
-        folderUuid,
+        teamUuid: teamUuid!,
+        folderUuid: folderUuid!,
       };
-
       if (selectedTags.length > 0) {
         options.tags = selectedTags;
       }
 
       const response = await linkApi.getLinks(options);
-      if (response.success) {
-        setLinks(response.data);
-      } else {
-        setLinks([]);
+      if (!response.success) {
+        throw new Error("링크를 불러오는데 실패했습니다.");
       }
-    } catch (err) {
-      setError("링크를 불러오는데 실패했습니다.");
-      console.error("링크 조회 실패:", err);
-      setLinks([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [teamUuid, folderUuid, selectedTags]);
+      return response.data;
+    },
+    enabled: !!teamUuid && !!folderUuid,
+  });
 
-  // teamUuid, folderUuid, selectedTags 변경 시 자동으로 링크 조회
-  useEffect(() => {
-    fetchLinks();
-  }, [fetchLinks]);
+  const error = queryError ? "링크를 불러오는데 실패했습니다." : null;
 
-  // 링크 삭제
-  const deleteLink = useCallback(async (linkUuid: string) => {
-    try {
-      await linkApi.deleteLink(linkUuid);
-      // 로컬 상태에서도 즉시 제거
-      setLinks((prev) => prev.filter((link) => link.linkUuid !== linkUuid));
-    } catch (err) {
-      console.error("링크 삭제 실패:", err);
-      throw err;
-    }
-  }, []);
+  // 링크 삭제 — 캐시에서 즉시 제거하여 UI에 반영
+  const deleteMutation = useMutation({
+    mutationFn: (linkUuid: string) => linkApi.deleteLink(linkUuid),
+    onSuccess: (_, linkUuid) => {
+      queryClient.setQueryData<Link[]>(queryKey, (prev) =>
+        (prev ?? []).filter((link) => link.linkUuid !== linkUuid),
+      );
+    },
+  });
+
+  const deleteLink = useCallback(
+    (linkUuid: string) => deleteMutation.mutateAsync(linkUuid),
+    [deleteMutation],
+  );
 
   // 태그 클릭 핸들러 - 태그 필터에 추가
   const handleTagClick = useCallback((tag: string) => {
@@ -109,7 +103,7 @@ export const useLinks = ({ teamUuid, folderUuid }: UseLinksOptions) => {
     error,
     selectedTags,
     searchQuery,
-    fetchLinks,
+    fetchLinks: refetch,
     deleteLink,
     setSearchQuery,
     handleTagClick,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.3)
       axios:
         specifier: ^1.13.2
         version: 1.13.2
@@ -321,6 +324,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.2
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.0
+        version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.3))(react@19.2.3)
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.8
@@ -1853,6 +1859,23 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/query-devtools@5.101.0':
+    resolution: {integrity: sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==}
+
+  '@tanstack/react-query-devtools@5.101.0':
+    resolution: {integrity: sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.0
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -7957,6 +7980,21 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/query-devtools@5.101.0': {}
+
+  '@tanstack/react-query-devtools@5.101.0(@tanstack/react-query@5.101.0(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.0
+      '@tanstack/react-query': 5.101.0(react@19.2.3)
+      react: 19.2.3
+
+  '@tanstack/react-query@5.101.0(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.3
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## 관련 이슈
Closes #294

`useLinks`가 매 fetch 직전 `setLoading(true)`로 데이터를 비우는 패턴이라 같은 폴더 재방문에도 빈 화면 → 스켈레톤 → 카드 사이클이 그대로 반복됨.

이를 풀기 위해 `useLinks`를 TanStack Query로 마이그레이션해 클라이언트 측 상태 캐싱을 도입함. 같은 `(team, folder, tags)` 조합은 `staleTime`(5분) 동안 캐시된 데이터를 그대로 보여주고 fetch 자체를 생략함. 5분이라는 값은, 본인의 추가/삭제가 mutation의 `setQueryData`로 즉시 반영되기 때문에 staleTime이 결국 "팀원이 바꾼 내용을 얼마나 빨리 보여줄지"만 결정한다는 판단에서 잡음. TeamStash가 비동기 협업 도메인이라 5분 정도의 지연은 사용자 마찰로 이어지지 않다고 판단함.

## 작업한 내용

먼저 `App.tsx`에 `QueryClientProvider`와 `ReactQueryDevtools`를 셋업하고, 기본 옵션을 `staleTime: 5분`, `gcTime: 10분`, `refetchOnWindowFocus: false`, `retry: 1`로 설정함. `useLinks` 내부에서는 `useState(links/loading/error)` + `useEffect` 자동 fetch 패턴을 `useQuery`로 교체했고, queryKey는 `["links", teamUuid, folderUuid, selectedTags]`로 잡아 태그 필터가 바뀔 때마다 별도 캐시에 들어가도록 함.

`deleteLink`는 `useMutation`으로 옮기고 `onSuccess`에서 `setQueryData`로 캐시를 즉시 갱신해, 추가 refetch 없이 카드가 사라지도록 함. `selectedTags`, `searchQuery` 같은 클라이언트 UI 상태는 `useState`로 그대로 둬서 서버 상태와 클라이언트 상태의 책임을 명시적으로 나눴고, 호출처 `TeamPage`는 인터페이스 호환을 유지해 변경 없이 그대로 동작함.

## 적용 범위

이번 PR은 `useLinks`만 시범 마이그레이션. `useFolders`, `useTeams`, `OAuthApps`의 oauth-apps 목록 등 같은 패턴이 반복되는 곳은 후속 PR에서 동일한 방식으로 적용할 예정. 

## 검증 시나리오

- [ ] DevTools Network 탭 → 같은 폴더 8번 반복 클릭 → `GET /links` 요청이 1회로 줄어드는지 (Before: 8회)
- [ ] 같은 폴더 재방문 시 깜빡임 없이 즉시 카드가 표시되는지
- [ ] 다른 폴더 → 첫 진입에는 fetch 발생, 다시 돌아오면 캐시 hit으로 깜빡임 없음
- [ ] 링크 삭제 → 카드가 즉시 사라지는지 (refetch 없이 캐시 즉시 갱신)
