### PR TITLE
Fix/296 useFolders를 TanStack Query로 마이그레이션해 폴더 클릭 깜빡임 제거

### DIFF
--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { Users } from "lucide-react";
 import type { Team, Folder as FolderType } from "../../types";
@@ -33,31 +33,9 @@ const Sidebar = ({
     null,
   );
 
-  // useFolders 훅 사용
-  const {
-    teamFolders,
-    fetchFoldersIfNeeded,
-    createFolder,
-    deleteFolder,
-    renameFolder,
-  } = useFolders({
-    selectedTeamUuid,
-  });
-
   // 수동으로 펼침/접힘 토글한 팀 상태 (localStorage 영속)
   const manualExpandedTeams = useSidebarStore((s) => s.manualExpandedTeams);
   const setTeamExpanded = useSidebarStore((s) => s.setTeamExpanded);
-
-  // 영속된 펼침 상태에 맞춰 진입 시 폴더 미리 fetch
-  // (이전엔 useState라 빈 상태로 시작했지만, store 영속으로 펼쳐진 팀이 살아 있을 수 있음)
-  useEffect(() => {
-    if (loading) return;
-    Object.entries(manualExpandedTeams).forEach(([teamUuid, expanded]) => {
-      if (expanded) {
-        fetchFoldersIfNeeded(teamUuid);
-      }
-    });
-  }, [loading, manualExpandedTeams, fetchFoldersIfNeeded]);
 
   // 팀이 펼쳐져 있는지 계산 (수동 상태 우선, 없으면 선택된 팀만 펼침)
   const isTeamExpanded = (teamUuid: string): boolean => {
@@ -70,15 +48,18 @@ const Sidebar = ({
     return false;
   };
 
-  const toggleTeamExpand = async (teamUuid: string) => {
-    const currentlyExpanded = isTeamExpanded(teamUuid);
-    const willExpand = !currentlyExpanded;
+  // useFolders 훅 사용 — 펼쳐진 팀과 선택된 팀의 폴더만 TanStack Query로 fetch.
+  // 캐싱은 라이브러리에 위임하므로 명시적 fetchFoldersIfNeeded 호출은 불필요.
+  const { teamFolders, createFolder, deleteFolder, renameFolder } = useFolders({
+    teams,
+    isTeamEnabled: isTeamExpanded,
+    selectedTeamUuid,
+  });
 
+  const toggleTeamExpand = (teamUuid: string) => {
+    const willExpand = !isTeamExpanded(teamUuid);
     setTeamExpanded(teamUuid, willExpand);
-
-    if (willExpand) {
-      await fetchFoldersIfNeeded(teamUuid);
-    }
+    // 펼치면 useFolders 안의 useQueries enabled가 true가 되어 자동 fetch
   };
 
   const handleTeamClick = (team: Team) => {

--- a/apps/frontend/src/hooks/useFolders.ts
+++ b/apps/frontend/src/hooks/useFolders.ts
@@ -1,158 +1,170 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useCallback, useMemo } from "react";
+import {
+  useMutation,
+  useQueries,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { folderApi } from "../services/api";
-import type { Folder } from "../types";
+import type { Folder, Team } from "../types";
 
 interface UseFoldersOptions {
+  teams: Team[];
+  isTeamEnabled?: (teamUuid: string) => boolean;
   selectedTeamUuid?: string;
 }
 
-// 폴더 관리를 위한 비즈니스 로직 훅
-export const useFolders = ({ selectedTeamUuid }: UseFoldersOptions) => {
-  // 팀별 폴더 데이터 캐시
-  const [teamFolders, setTeamFolders] = useState<Record<string, Folder[]>>({});
-  // 이미 폴더를 조회한 팀 추적 (중복 API 호출 방지)
-  const fetchedFoldersRef = useRef<Set<string>>(new Set());
+// 폴더 관리 훅
+// 수동 캐싱(useState + useRef)을 TanStack Query에 위임.
+// 활성화된 팀들에 대해 useQueries로 fetch하고, mutation은 setQueryData로 즉시 캐시 반영.
+export const useFolders = ({
+  teams,
+  isTeamEnabled,
+  selectedTeamUuid,
+}: UseFoldersOptions) => {
+  const queryClient = useQueryClient();
 
-  // 폴더 조회 (필요한 경우에만)
-  // 이미 조회한 팀은 캐시 사용
-  const fetchFoldersIfNeeded = useCallback(async (teamUuid: string) => {
-    if (fetchedFoldersRef.current.has(teamUuid)) return;
+  // 활성화된 팀들의 폴더만 fetch (펼쳐진 팀 + 선택된 팀)
+  const folderQueries = useQueries({
+    queries: teams.map((team) => ({
+      queryKey: ["folders", team.teamUuid] as const,
+      queryFn: async (): Promise<Folder[]> => {
+        const response = await folderApi.getFolders(team.teamUuid);
+        return response.success ? response.data : [];
+      },
+      enabled:
+        team.teamUuid === selectedTeamUuid ||
+        (isTeamEnabled ? isTeamEnabled(team.teamUuid) : false),
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
 
-    fetchedFoldersRef.current.add(teamUuid);
-    try {
-      const response = await folderApi.getFolders(teamUuid);
-      if (response.success) {
-        setTeamFolders((prev) => ({
-          ...prev,
-          [teamUuid]: response.data,
-        }));
-      }
-    } catch (error) {
-      console.error("폴더 조회 실패:", error);
-      fetchedFoldersRef.current.delete(teamUuid);
-    }
-  }, []);
+  // teamFolders Record 만들기 (기존 인터페이스 호환)
+  const teamFolders = useMemo(() => {
+    const record: Record<string, Folder[]> = {};
+    teams.forEach((team, index) => {
+      const data = folderQueries[index]?.data;
+      if (data) record[team.teamUuid] = data;
+    });
+    return record;
+    // folderQueries 자체는 매 렌더마다 새 array — data만 의존하도록 풀어서 의존성에 넣음
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [teams, ...folderQueries.map((q) => q.data)]);
 
-  // 폴더 강제 재조회
-  // 캐시를 무효화하고 다시 조회
-  const refetchFolders = useCallback(
+  // 명시적 fetch 트리거 (호환 유지 — toggle 시점에 호출되지만 enabled로 이미 자동 처리됨)
+  const fetchFoldersIfNeeded = useCallback(
     async (teamUuid: string) => {
-      fetchedFoldersRef.current.delete(teamUuid);
-      await fetchFoldersIfNeeded(teamUuid);
+      await queryClient.fetchQuery({
+        queryKey: ["folders", teamUuid],
+        queryFn: async (): Promise<Folder[]> => {
+          const response = await folderApi.getFolders(teamUuid);
+          return response.success ? response.data : [];
+        },
+        staleTime: 5 * 60 * 1000,
+      });
     },
-    [fetchFoldersIfNeeded],
+    [queryClient],
   );
 
-  // 특정 팀의 폴더 목록 반환
-  const getFoldersByTeam = useCallback(
-    (teamUuid: string) => {
-      return teamFolders[teamUuid] || [];
+  // 폴더 생성 — 성공 시 캐시에 즉시 추가
+  const createFolderMutation = useMutation({
+    mutationFn: async ({
+      teamUuid,
+      folderName,
+    }: {
+      teamUuid: string;
+      folderName: string;
+    }) => {
+      const response = await folderApi.createFolder({ teamUuid, folderName });
+      if (!response.success) {
+        throw new Error(response.message || "폴더 생성 실패");
+      }
+      return { teamUuid, folder: response.data };
     },
-    [teamFolders],
-  );
+    onSuccess: ({ teamUuid, folder }) => {
+      queryClient.setQueryData<Folder[]>(["folders", teamUuid], (prev) => [
+        ...(prev ?? []),
+        folder,
+      ]);
+    },
+  });
 
-  // 폴더 생성
-  // api 호출 후 성고하면 캐시(teamFolders)에 직접 추가
-  // api를 다시 호출할 필요 없이 즉시 Ui에 반영
   const createFolder = useCallback(
     async (teamUuid: string, folderName: string): Promise<Folder> => {
-      const response = await folderApi.createFolder({ teamUuid, folderName });
-
-      if (response.success) {
-        // 캐시에 새 폴더 추가 (API 재호출 없이 즉시 반영)
-        setTeamFolders((prev) => ({
-          ...prev,
-          [teamUuid]: [...(prev[teamUuid] || []), response.data],
-        }));
-        return response.data;
-      }
-
-      throw new Error(response.message || "폴더 생성 실패");
+      const { folder } = await createFolderMutation.mutateAsync({
+        teamUuid,
+        folderName,
+      });
+      return folder;
     },
-    [],
+    [createFolderMutation],
   );
 
-  // 폴더 삭제
-  // api 호출 후 성공하면 캐시(teamFolder)에서 직접 제거
-  // api를 다시 호출할 필요 없이 즉시 ui에 반영
+  // 폴더 삭제 — 성공 시 캐시에서 즉시 제거
+  const deleteFolderMutation = useMutation({
+    mutationFn: async ({
+      teamUuid,
+      folderUuid,
+    }: {
+      teamUuid: string;
+      folderUuid: string;
+    }) => {
+      await folderApi.deleteFolder(folderUuid);
+      return { teamUuid, folderUuid };
+    },
+    onSuccess: ({ teamUuid, folderUuid }) => {
+      queryClient.setQueryData<Folder[]>(["folders", teamUuid], (prev) =>
+        (prev ?? []).filter((f) => f.folderUuid !== folderUuid),
+      );
+    },
+  });
+
   const deleteFolder = useCallback(
     async (teamUuid: string, folderUuid: string): Promise<void> => {
-      await folderApi.deleteFolder(folderUuid);
-
-      // 캐시에서 해당 폴더 제거 (API 재호출 없이 즉시 반영)
-      setTeamFolders((prev) => ({
-        ...prev,
-        [teamUuid]: (prev[teamUuid] || []).filter(
-          (f) => f.folderUuid !== folderUuid,
-        ),
-      }));
+      await deleteFolderMutation.mutateAsync({ teamUuid, folderUuid });
     },
-    [],
+    [deleteFolderMutation],
   );
 
-  // 폴더 이름 수정
+  // 폴더 이름 변경 — 성공 시 캐시에서 즉시 수정
+  const renameFolderMutation = useMutation({
+    mutationFn: async ({
+      folderUuid,
+      newName,
+    }: {
+      teamUuid: string;
+      folderUuid: string;
+      newName: string;
+    }) => {
+      const response = await folderApi.updateFolder(folderUuid, {
+        folderName: newName,
+      });
+      if (!response.success) {
+        throw new Error("폴더 이름 수정 실패");
+      }
+    },
+    onSuccess: (_, { teamUuid, folderUuid, newName }) => {
+      queryClient.setQueryData<Folder[]>(["folders", teamUuid], (prev) =>
+        (prev ?? []).map((f) =>
+          f.folderUuid === folderUuid ? { ...f, folderName: newName } : f,
+        ),
+      );
+    },
+  });
+
   const renameFolder = useCallback(
     async (
       teamUuid: string,
       folderUuid: string,
       newName: string,
     ): Promise<void> => {
-      const response = await folderApi.updateFolder(folderUuid, {
-        folderName: newName,
-      });
-
-      if (response.success) {
-        // 캐시에서 해당 폴더 이름 업데이트
-        setTeamFolders((prev) => ({
-          ...prev,
-          [teamUuid]: (prev[teamUuid] || []).map((f) =>
-            f.folderUuid === folderUuid ? { ...f, folderName: newName } : f,
-          ),
-        }));
-      }
+      await renameFolderMutation.mutateAsync({ teamUuid, folderUuid, newName });
     },
-    [],
+    [renameFolderMutation],
   );
-
-  // 선택된 팀의 폴더 자동 조회 (URL 변경 시)
-  useEffect(() => {
-    if (!selectedTeamUuid) return;
-
-    // 이미 폴더 데이터가 있으면 스킵
-    if (teamFolders[selectedTeamUuid]) return;
-
-    let cancelled = false;
-
-    const fetchFolders = async () => {
-      fetchedFoldersRef.current.add(selectedTeamUuid);
-      try {
-        const response = await folderApi.getFolders(selectedTeamUuid);
-        if (!cancelled && response.success) {
-          setTeamFolders((prev) => ({
-            ...prev,
-            [selectedTeamUuid]: response.data,
-          }));
-        }
-      } catch (error) {
-        console.error("폴더 조회 실패:", error);
-        if (!cancelled) {
-          fetchedFoldersRef.current.delete(selectedTeamUuid);
-        }
-      }
-    };
-
-    fetchFolders();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedTeamUuid, teamFolders]);
 
   return {
     teamFolders,
     fetchFoldersIfNeeded,
-    refetchFolders,
-    getFoldersByTeam,
     createFolder,
     deleteFolder,
     renameFolder,


### PR DESCRIPTION
useFolders`가 수동 캐싱(`useState + useRef`)을 직접 구현하고 있었는데 실제 측정에서는 폴더 클릭마다 `GET /folders`가 6번 반복 발생하고 있었습니다,

이에 `useLinks`(#294)와 같은 방식으로 `useFolders`도 TanStack Query로 마이그레이션하고 queryKey는 `["folders", teamUuid]` 단위로 분리되어 팀별로 캐시가 따로 관리되도록 했습니다.

## 작업한 내용

`useFolders`를 통째 재작성함. `useState + useRef`로 직접 들고 있던 캐시(`teamFolders`, `fetchedFoldersRef`)를 제거하고, 활성화된 팀들의 폴더를 `useQueries`로 fetch하도록 위임함. `enabled` 옵션이 펼침/선택 상태에 맞춰 자동으로 fetch를 트리거함.

`createFolder`, `deleteFolder`, `renameFolder`는 `useMutation`으로 옮기고, 각 `onSuccess`에서 `setQueryData`로 캐시를 즉시 갱신해 refetch 없이 UI에 반영되도록 함. 기존 호출처(`CreateFolderModal`, `TeamItem` 등)와의 인터페이스 호환 유지.

`Sidebar.tsx`에서는 `useFolders`에 `teams`와 `isTeamEnabled`(= `isTeamExpanded`)를 넘기도록 호출을 바꿨고, 영속된 펼침 상태에 맞춰 진입 시 미리 fetch하던 `useEffect`와 `toggleTeamExpand` 안의 명시적 `fetchFoldersIfNeeded` 호출은 제거함. 두 작업 모두 `useQueries`의 `enabled`가 자동으로 처리.

## 검증 시나리오

배포 후 시크릿 모드에서 다음을 확인:

- [ ] 폴더 A → 폴더 B → 폴더 A 왕복 시 Network 탭에 `GET /folders` 요청이 사실상 사라지는지 (Before: 6회 / After: 0회 예상, 첫 진입 1회 제외)
- [ ] 폴더 클릭 시 페이지 깜빡임 없이 카드가 즉시 표시되는지
- [ ] 팀을 새로 펼칠 때만 해당 팀의 `GET /folders`가 1회 발생하는지 (`enabled` 자동 처리)
- [ ] 폴더 생성/삭제/이름 변경 후 사이드바에 즉시 반영되는지 (캐시 즉시 갱신)

## 관련 이슈
Closes #296
