### PR TITLE
test: Zustand store + TanStack Query 훅 회귀 방지 테스트 추가

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -26,6 +26,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tanstack/react-query-devtools": "^5.101.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/apps/frontend/src/hooks/useFolders.test.tsx
+++ b/apps/frontend/src/hooks/useFolders.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useFolders } from "./useFolders";
+import type { Team } from "../types";
+
+vi.mock("../services/api", () => ({
+  folderApi: {
+    getFolders: vi.fn(),
+    createFolder: vi.fn(),
+    deleteFolder: vi.fn(),
+    updateFolder: vi.fn(),
+  },
+}));
+
+import { folderApi } from "../services/api";
+
+const mockedGetFolders = folderApi.getFolders as ReturnType<typeof vi.fn>;
+const mockedCreateFolder = folderApi.createFolder as ReturnType<typeof vi.fn>;
+const mockedDeleteFolder = folderApi.deleteFolder as ReturnType<typeof vi.fn>;
+const mockedUpdateFolder = folderApi.updateFolder as ReturnType<typeof vi.fn>;
+
+const teamA: Team = {
+  teamUuid: "team-A",
+  teamName: "Team A",
+} as Team;
+const teamB: Team = {
+  teamUuid: "team-B",
+  teamName: "Team B",
+} as Team;
+
+const foldersA = [
+  { folderUuid: "folder-A1", folderName: "A-1" },
+  { folderUuid: "folder-A2", folderName: "A-2" },
+];
+const foldersB = [{ folderUuid: "folder-B1", folderName: "B-1" }];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 5 * 60 * 1000 },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetFolders.mockImplementation((teamUuid: string) => {
+    if (teamUuid === "team-A") {
+      return Promise.resolve({ success: true, data: foldersA });
+    }
+    if (teamUuid === "team-B") {
+      return Promise.resolve({ success: true, data: foldersB });
+    }
+    return Promise.resolve({ success: false, data: [] });
+  });
+});
+
+describe("useFolders", () => {
+  describe("enabled / useQueries fetch 동작", () => {
+    it("isTeamEnabled가 false인 팀은 fetch하지 않는다", async () => {
+      renderHook(
+        () =>
+          useFolders({
+            teams: [teamA, teamB],
+            isTeamEnabled: () => false,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockedGetFolders).not.toHaveBeenCalled();
+    });
+
+    it("isTeamEnabled가 true인 팀만 fetch한다", async () => {
+      const { result } = renderHook(
+        () =>
+          useFolders({
+            teams: [teamA, teamB],
+            isTeamEnabled: (uuid) => uuid === "team-A",
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual(foldersA);
+      });
+
+      expect(mockedGetFolders).toHaveBeenCalledTimes(1);
+      expect(mockedGetFolders).toHaveBeenCalledWith("team-A");
+      expect(result.current.teamFolders["team-B"]).toBeUndefined();
+    });
+
+    it("selectedTeamUuid의 팀은 isTeamEnabled와 무관하게 fetch한다", async () => {
+      const { result } = renderHook(
+        () =>
+          useFolders({
+            teams: [teamA, teamB],
+            isTeamEnabled: () => false,
+            selectedTeamUuid: "team-B",
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-B"]).toEqual(foldersB);
+      });
+
+      expect(mockedGetFolders).toHaveBeenCalledWith("team-B");
+      expect(result.current.teamFolders["team-A"]).toBeUndefined();
+    });
+  });
+
+  describe("createFolder (useMutation + setQueryData)", () => {
+    it("createFolder 호출 후 캐시에 새 폴더가 추가된다", async () => {
+      const newFolder = { folderUuid: "folder-A3", folderName: "A-3" };
+      mockedCreateFolder.mockResolvedValue({ success: true, data: newFolder });
+
+      const { result } = renderHook(
+        () =>
+          useFolders({
+            teams: [teamA],
+            isTeamEnabled: () => true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual(foldersA);
+      });
+
+      await act(async () => {
+        await result.current.createFolder("team-A", "A-3");
+      });
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual([
+          ...foldersA,
+          newFolder,
+        ]);
+      });
+
+      expect(mockedCreateFolder).toHaveBeenCalledWith({
+        teamUuid: "team-A",
+        folderName: "A-3",
+      });
+    });
+  });
+
+  describe("deleteFolder (useMutation + setQueryData)", () => {
+    it("deleteFolder 호출 후 캐시에서 해당 폴더가 제거된다", async () => {
+      mockedDeleteFolder.mockResolvedValue(undefined);
+
+      const { result } = renderHook(
+        () =>
+          useFolders({
+            teams: [teamA],
+            isTeamEnabled: () => true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual(foldersA);
+      });
+
+      await act(async () => {
+        await result.current.deleteFolder("team-A", "folder-A1");
+      });
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual([
+          { folderUuid: "folder-A2", folderName: "A-2" },
+        ]);
+      });
+
+      expect(mockedDeleteFolder).toHaveBeenCalledWith("folder-A1");
+    });
+  });
+
+  describe("renameFolder (useMutation + setQueryData)", () => {
+    it("renameFolder 호출 후 캐시에서 해당 폴더 이름이 변경된다", async () => {
+      mockedUpdateFolder.mockResolvedValue({
+        success: true,
+        data: { folderUuid: "folder-A1", folderName: "A-1-renamed" },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useFolders({
+            teams: [teamA],
+            isTeamEnabled: () => true,
+          }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual(foldersA);
+      });
+
+      await act(async () => {
+        await result.current.renameFolder("team-A", "folder-A1", "A-1-renamed");
+      });
+
+      await waitFor(() => {
+        expect(result.current.teamFolders["team-A"]).toEqual([
+          { folderUuid: "folder-A1", folderName: "A-1-renamed" },
+          { folderUuid: "folder-A2", folderName: "A-2" },
+        ]);
+      });
+
+      expect(mockedUpdateFolder).toHaveBeenCalledWith("folder-A1", {
+        folderName: "A-1-renamed",
+      });
+    });
+  });
+});

--- a/apps/frontend/src/hooks/useLinks.test.tsx
+++ b/apps/frontend/src/hooks/useLinks.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useLinks } from "./useLinks";
+
+vi.mock("../services/api", () => ({
+  linkApi: {
+    getLinks: vi.fn(),
+    deleteLink: vi.fn(),
+  },
+}));
+
+import { linkApi } from "../services/api";
+
+const mockedGetLinks = linkApi.getLinks as ReturnType<typeof vi.fn>;
+const mockedDeleteLink = linkApi.deleteLink as ReturnType<typeof vi.fn>;
+
+const mockLinks = [
+  {
+    linkUuid: "link-1",
+    title: "Link 1",
+    summary: "",
+    tags: [],
+    url: "https://1.com",
+    createdAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    linkUuid: "link-2",
+    title: "Link 2",
+    summary: "",
+    tags: ["foo"],
+    url: "https://2.com",
+    createdAt: "2026-01-02T00:00:00Z",
+  },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 5 * 60 * 1000 },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetLinks.mockResolvedValue({ success: true, data: mockLinks });
+  mockedDeleteLink.mockResolvedValue({ success: true });
+});
+
+describe("useLinks", () => {
+  describe("fetch 동작 (useQuery)", () => {
+    it("teamUuid + folderUuid가 모두 있으면 GET /links를 호출한다", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(mockedGetLinks).toHaveBeenCalledTimes(1);
+      expect(mockedGetLinks).toHaveBeenCalledWith({
+        teamUuid: "team-1",
+        folderUuid: "folder-1",
+      });
+      expect(result.current.links).toEqual(mockLinks);
+    });
+
+    it("teamUuid가 없으면 fetch하지 않는다 (enabled: false)", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: undefined, folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockedGetLinks).not.toHaveBeenCalled();
+      expect(result.current.links).toEqual([]);
+    });
+
+    it("folderUuid가 없으면 fetch하지 않는다 (enabled: false)", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: undefined }),
+        { wrapper: createWrapper() },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockedGetLinks).not.toHaveBeenCalled();
+      expect(result.current.links).toEqual([]);
+    });
+  });
+
+  describe("deleteLink (useMutation + setQueryData)", () => {
+    it("deleteLink 호출 후 캐시에서 해당 링크가 즉시 제거된다", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.links.length).toBe(2);
+      });
+
+      await act(async () => {
+        await result.current.deleteLink("link-1");
+      });
+
+      expect(mockedDeleteLink).toHaveBeenCalledWith("link-1");
+      await waitFor(() => {
+        expect(result.current.links).toEqual([
+          expect.objectContaining({ linkUuid: "link-2" }),
+        ]);
+      });
+    });
+
+    it("deleteLink 후 추가 fetch가 발생하지 않는다 (refetch 없이 캐시 갱신)", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.links.length).toBe(2);
+      });
+
+      const fetchCountBefore = mockedGetLinks.mock.calls.length;
+
+      await act(async () => {
+        await result.current.deleteLink("link-1");
+      });
+
+      expect(mockedGetLinks.mock.calls.length).toBe(fetchCountBefore);
+    });
+  });
+
+  describe("filteredLinks (검색·태그 필터)", () => {
+    it("초기 searchQuery가 비어있으면 모든 링크를 반환한다", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.links.length).toBe(2);
+      });
+
+      expect(result.current.filteredLinks).toEqual(mockLinks);
+    });
+
+    it("searchQuery로 제목을 검색하면 일치하는 링크만 반환한다", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.links.length).toBe(2);
+      });
+
+      act(() => {
+        result.current.setSearchQuery("Link 1");
+      });
+
+      await waitFor(() => {
+        expect(result.current.filteredLinks).toEqual([
+          expect.objectContaining({ linkUuid: "link-1" }),
+        ]);
+      });
+    });
+
+    it("handleTagClick으로 태그를 추가하면 selectedTags에 들어간다", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.links.length).toBe(2);
+      });
+
+      act(() => {
+        result.current.handleTagClick("foo");
+      });
+
+      expect(result.current.selectedTags).toEqual(["foo"]);
+    });
+
+    it("같은 태그를 두 번 클릭해도 중복 추가되지 않는다", async () => {
+      const { result } = renderHook(
+        () => useLinks({ teamUuid: "team-1", folderUuid: "folder-1" }),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(result.current.links.length).toBe(2);
+      });
+
+      act(() => {
+        result.current.handleTagClick("foo");
+        result.current.handleTagClick("foo");
+      });
+
+      expect(result.current.selectedTags).toEqual(["foo"]);
+    });
+  });
+});

--- a/apps/frontend/src/stores/sidebar.store.test.ts
+++ b/apps/frontend/src/stores/sidebar.store.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSidebarStore } from "./sidebar.store";
+
+describe("useSidebarStore", () => {
+  beforeEach(() => {
+    // 각 테스트 전 store + localStorage 초기화
+    useSidebarStore.setState({ manualExpandedTeams: {} });
+    localStorage.clear();
+  });
+
+  describe("초기 상태", () => {
+    it("manualExpandedTeams는 빈 객체로 시작한다", () => {
+      expect(useSidebarStore.getState().manualExpandedTeams).toEqual({});
+    });
+
+    it("setTeamExpanded 액션이 정의되어 있다", () => {
+      expect(typeof useSidebarStore.getState().setTeamExpanded).toBe("function");
+    });
+  });
+
+  describe("setTeamExpanded", () => {
+    it("팀을 펼침 상태(true)로 설정한다", () => {
+      useSidebarStore.getState().setTeamExpanded("team-1", true);
+      expect(useSidebarStore.getState().manualExpandedTeams).toEqual({
+        "team-1": true,
+      });
+    });
+
+    it("팀을 접힘 상태(false)로 설정한다", () => {
+      useSidebarStore.getState().setTeamExpanded("team-1", true);
+      useSidebarStore.getState().setTeamExpanded("team-1", false);
+      expect(useSidebarStore.getState().manualExpandedTeams).toEqual({
+        "team-1": false,
+      });
+    });
+
+    it("여러 팀의 상태를 독립적으로 관리한다", () => {
+      const { setTeamExpanded } = useSidebarStore.getState();
+      setTeamExpanded("team-1", true);
+      setTeamExpanded("team-2", false);
+      setTeamExpanded("team-3", true);
+
+      expect(useSidebarStore.getState().manualExpandedTeams).toEqual({
+        "team-1": true,
+        "team-2": false,
+        "team-3": true,
+      });
+    });
+
+    it("한 팀 상태를 변경해도 다른 팀 상태는 유지된다", () => {
+      const { setTeamExpanded } = useSidebarStore.getState();
+      setTeamExpanded("team-1", true);
+      setTeamExpanded("team-2", true);
+      setTeamExpanded("team-1", false);
+
+      expect(useSidebarStore.getState().manualExpandedTeams).toEqual({
+        "team-1": false,
+        "team-2": true,
+      });
+    });
+  });
+
+  describe("persist middleware (localStorage 영속화)", () => {
+    it("setTeamExpanded 호출 시 localStorage 'sidebar-state' 키에 저장된다", () => {
+      useSidebarStore.getState().setTeamExpanded("team-1", true);
+
+      const stored = localStorage.getItem("sidebar-state");
+      expect(stored).not.toBeNull();
+    });
+
+    it("저장된 값은 manualExpandedTeams를 포함한다", () => {
+      useSidebarStore.getState().setTeamExpanded("team-1", true);
+      useSidebarStore.getState().setTeamExpanded("team-2", false);
+
+      const stored = JSON.parse(localStorage.getItem("sidebar-state")!);
+      expect(stored.state.manualExpandedTeams).toEqual({
+        "team-1": true,
+        "team-2": false,
+      });
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,15 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.101.0
         version: 5.101.0(@tanstack/react-query@5.101.0(react@19.2.3))(react@19.2.3)
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.8


### PR DESCRIPTION
#292(Zustand persist)·#294(useLinks)·#296(useFolders)에서 진행한 마이그레이션이 다시 깨지지 않도록 회귀 방지 테스트가 필요해 보여서 vitest 기반 단위 테스트 23개를 추가했습니다.

## 작업한 내용

`src/stores/sidebar.store.test.ts` (8 tests) — Zustand store 테스트. 초기 상태가 빈 객체임, `setTeamExpanded`가 여러 팀의 상태를 독립적으로 관리함, 한 팀 변경이 다른 팀에 영향 없음, `persist` middleware가 localStorage `sidebar-state` 키에 `manualExpandedTeams`를 저장함을 검증.

`src/hooks/useLinks.test.tsx` (9 tests) — TanStack Query 훅 테스트. `enabled` 조건(teamUuid + folderUuid)에 따라 `getLinks` 호출 여부 검증, `deleteLink` mutation 호출 후 `setQueryData`로 캐시에서 즉시 제거되고 refetch가 발생하지 않음을 확인, `filteredLinks`의 검색·태그 동작과 중복 방지까지 검증.

`src/hooks/useFolders.test.tsx` (6 tests) — `useQueries` `enabled` 동작(`isTeamEnabled`/`selectedTeamUuid`)에 따른 fetch 분리 검증, `createFolder`/`deleteFolder`/`renameFolder` mutation 후 `setQueryData`로 캐시가 즉시 갱신되는 흐름 검증.

테스트 도구는 `@testing-library/react`를 dev dependency로 추가하고, 각 hook 테스트는 `QueryClientProvider` wrapper로 격리된 `QueryClient`를 주입함. 기존 `vitest` + `jsdom` 셋업을 그대로 활용.

## 검증

- [ ] `pnpm --filter frontend test` → 4 files / 29 tests passing (기존 `api.test.ts` 6 + 신규 23)
- [ ] 회귀 발생 시 어떤 store/훅의 어떤 동작이 깨졌는지 테스트 이름으로 즉시 파악 가능

## 적용 범위

이번 PR은 store + 훅 단위 테스트만. 페이지/컴포넌트 통합 테스트, e2e 테스트는 후속 PR로 분리합니다.
